### PR TITLE
Fix macOS code signing error with resvg-wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1] - 2026-02-23
 
+### Fixed
+
+- Replace `@resvg/resvg-js` (native napi-rs addon) with `@resvg/resvg-wasm` to fix macOS code signing error (`dlopen` failure) when running as a compiled Bun binary
+
 ### Added
 
 - Initial project scaffold with MCP server skeleton

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Use `loadAllLines` + `scanLines` when a tool needs multiple passes over the same
 
 ### SVG Rendering
 
-The `render_net` tool generates SVG internally, then converts to PNG via `@resvg/resvg-js` before returning as MCP image content. This is necessary because Claude's API only accepts raster image formats (PNG, JPEG, WebP, GIF) — not SVG. A 1200px PNG costs ~1K tokens regardless of net complexity.
+The `render_net` tool generates SVG internally, then converts to PNG via `@resvg/resvg-wasm` before returning as MCP image content. This is necessary because Claude's API only accepts raster image formats (PNG, JPEG, WebP, GIF) — not SVG. A 1200px PNG costs ~1K tokens regardless of net complexity. The WASM variant is used instead of the native `@resvg/resvg-js` to avoid macOS code signing conflicts when running as a compiled Bun binary.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/IntelligentElectron/pcb-lens#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@resvg/resvg-js": "^2.6.2",
+    "@resvg/resvg-wasm": "^2.6.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { Resvg } from "@resvg/resvg-js";
+import { Resvg, initWasm } from "@resvg/resvg-wasm";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { z } from "zod";
 import { VERSION } from "./version.js";
 import { getDesignOverview, queryComponents, queryNet, renderNet } from "./service.js";
@@ -58,14 +60,25 @@ const formatResult = (result: unknown): { content: { type: "text"; text: string 
   content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
 });
 
+let wasmInitialized = false;
+
+const ensureWasmInitialized = async (): Promise<void> => {
+  if (wasmInitialized) return;
+  const wasmUrl = import.meta.resolve("@resvg/resvg-wasm/index_bg.wasm");
+  const wasmBuffer = await readFile(fileURLToPath(wasmUrl));
+  await initWasm(wasmBuffer);
+  wasmInitialized = true;
+};
+
 /**
- * Render SVG to PNG using resvg, return as MCP image content + stats text.
+ * Render SVG to PNG using resvg-wasm, return as MCP image content + stats text.
  */
-const formatRenderResult = (
+const formatRenderResult = async (
   result: RenderNetResult
-): {
+): Promise<{
   content: ({ type: "text"; text: string } | { type: "image"; data: string; mimeType: string })[];
-} => {
+}> => {
+  await ensureWasmInitialized();
   const resvg = new Resvg(result.svg, { fitTo: { mode: "width", value: 1200 } });
   const png = resvg.render().asPng();
 
@@ -185,7 +198,7 @@ export const createServer = (): McpServer => {
     async ({ file, pattern }) => {
       const result = await renderNet(file, pattern);
       if (isErrorResult(result)) return formatResult(result);
-      return formatRenderResult(result);
+      return await formatRenderResult(result);
     }
   );
 


### PR DESCRIPTION
## Summary

- Replace `@resvg/resvg-js` (native napi-rs addon) with `@resvg/resvg-wasm` (WebAssembly) to fix `dlopen` / code signing failure on macOS when running the compiled Bun binary
- Add lazy WASM initialization in `formatRenderResult` — same `Resvg` API, no behavioral change
- Update CLAUDE.md and CHANGELOG.md

## Context

The native `.node` addon gets extracted to `/tmp` at runtime by Bun's compiled binary. macOS Gatekeeper blocks `dlopen` because the extracted file has a different Team ID than the signed main binary. The WASM variant avoids this entirely — no native file, no `dlopen`.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 58 passed, 12 skipped
- [x] `npm run compile` — binary builds
- [x] `bin/pcb-lens --version` — no dlopen error
- [x] `render_net` smoke test — 44.8 KB PNG, 57 pins, 69 traces, 5 layers