### PR TITLE
Fix changelog format to match convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.0.2] - 2026-02-23
 
 ### Added
@@ -34,3 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test fixture download script for IPC-2581 consortium samples
 - Release automation with CI workflows and binary compilation
 - Integration tests against IPC-2581 consortium fixtures
+
+[0.0.2]: https://github.com/IntelligentElectron/pcb-lens/releases/tag/v0.0.2
+[0.0.1]: https://github.com/IntelligentElectron/pcb-lens/releases/tag/v0.0.1


### PR DESCRIPTION
## Summary

- Remove `[Unreleased]` section (not used in this project)
- Add release tag links at bottom matching universal-netlist convention