### PR TITLE
docs: remove Gemini CLI and VS Code (GitHub Copilot) from supported MCP clients

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ What actually happened.
 
 - OS: [e.g., macOS 14.0, Windows 11, Ubuntu 22.04]
 - Node.js version: [e.g., 20.10.0]
-- MCP Client: [e.g., Claude Code, Claude Desktop, VS Code]
+- MCP Client: [e.g., Claude Code, Claude Desktop]
 
 ## Input Format
 

--- a/README.md
+++ b/README.md
@@ -103,33 +103,6 @@ Install [OpenAI Codex](https://developers.openai.com/codex/cli/), then run:
 codex mcp add pcb-lens -- pcb-lens
 ```
 
-### Gemini CLI
-
-Install [Gemini CLI](https://geminicli.com/docs/get-started/installation/), then run:
-
-```bash
-gemini mcp add --scope user pcb-lens pcb-lens
-```
-
-### VS Code (GitHub Copilot)
-
-Download [VS Code](https://code.visualstudio.com/)
-
-Add to `.vscode/mcp.json` in your project:
-
-```json
-{
-  "servers": {
-    "pcb-lens": {
-      "type": "stdio",
-      "command": "pcb-lens"
-    }
-  }
-}
-```
-
-Then enable it in **Configure Tools** (click the tools icon in Copilot chat).
-
 ## Supported Platforms
 
 | Platform | Binary |


### PR DESCRIPTION
Removes Gemini CLI and VS Code (GitHub Copilot) from the list of supported MCP clients.

- **README.md** — drop the `### Gemini CLI` and `### VS Code (GitHub Copilot)` install sections.
- **.github/ISSUE_TEMPLATE/bug_report.md** — remove `VS Code` from the MCP-client example list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)