### PR TITLE
feat: OpenTelemetry instrumentation and 1.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ test/integration/fixtures/
 # Telemetry
 telemetry.jsonl
 telemetry-*.zip
+
+# Playwright artifacts
+.playwright*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-06-17
+
+First stable release.
+
+### Added
+
+- OpenTelemetry instrumentation: every tool call emits a span (`tool/<tool_name>`), metrics (`tool.calls`, `tool.duration`, `tool.errors`), and a structured log correlated by trace/span id, exported to any OTLP-compatible backend purely via the standard `OTEL_*` environment variables. Disabled and zero-overhead unless an OTLP endpoint is configured
+- `enduser.id` resource attribute set from the host OS account name, attributing telemetry to the per-session user across traces, metrics, and logs
+- Opt-in raw tool-argument capture on spans via `OTEL_CAPTURE_TOOL_ARGS=1` (off by default)
+
+### Changed
+
+- Consolidated telemetry into `src/telemetry/`: local JSONL usage analytics (`local`) and OpenTelemetry (`otel`) behind a single barrel
+
+### Fixed
+
+- Self-update now runs only for the compiled standalone binary; running from source (tsx/node) no longer performs a GitHub update check or re-execs into a downloaded binary
+
 ## [0.1.0] - 2026-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,6 +112,50 @@ codex mcp add pcb-lens -- pcb-lens
 | Linux (ARM64) | `pcb-lens-linux-arm64` |
 | Windows (x64) | `pcb-lens-windows-x64.exe` |
 
+## Observability (OpenTelemetry)
+
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral: it works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
+
+**Disabled by default.** Telemetry is a no-op with zero overhead unless you set an OTLP endpoint. Turn it on purely with the standard `OTEL_*` environment variables; no code changes and no bespoke config.
+
+Each tool call emits:
+
+- a span `tool/<tool_name>` with `tool.name`, `tool.outcome` (`success`/`error`), `tool.duration_ms`, and `error.type` on failure;
+- metrics `tool.calls` (counter), `tool.duration` (ms histogram), and `tool.errors` (counter), labeled by `tool` and `outcome`;
+- a structured log record carrying the active trace/span IDs for trace-to-log correlation.
+
+All telemetry is tagged with `enduser.id`, the host OS account name of whoever is running the server, as a resource attribute (so it appears on traces, metrics, and logs). This attributes usage to the per-session user without any configuration.
+
+### Quick start with a local Collector / Jaeger
+
+Run an all-in-one Jaeger (which accepts OTLP and renders traces) and point the server at it:
+
+```bash
+docker run --rm -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
+
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_SERVICE_NAME=pcb-lens
+# then start the MCP server as usual; open http://localhost:16686 to view traces
+```
+
+### Configuration
+
+Only standard OpenTelemetry environment variables are used:
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint to export to. **Setting this enables telemetry.** |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers for the exporter, e.g. `Authorization=Bearer <token>` for a managed backend. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is not bundled in the standalone binaries and falls back to `http/protobuf`. |
+| `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` | Resource identity. |
+| `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, ... | Standard OTel SDK knobs. |
+
+Additional, clearly-scoped options:
+
+- `OTEL_CAPTURE_TOOL_ARGS=1`: also record raw tool arguments on the span (off by default; arguments may be sensitive).
+
+Telemetry never affects tool results: exporter failures, misconfiguration, or an unreachable backend degrade to "no telemetry", and pending data is flushed on shutdown.
+
 ## Documentation
 
 See [docs/](docs/README.md) for API documentation and response schemas.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/pcb-lens",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "MCP server for IPC-2581 PCB layout analysis and review",
   "type": "module",
   "main": "dist/index.js",
@@ -64,6 +64,18 @@
   "homepage": "https://github.com/IntelligentElectron/pcb-lens#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.219.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.219.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.219.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-logs": "^0.219.0",
+    "@opentelemetry/sdk-metrics": "^2.8.0",
+    "@opentelemetry/sdk-node": "^0.219.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "zod": "^4.3.6"
   },

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -5,13 +5,9 @@
 import { existsSync, rmSync } from "node:fs";
 import { dirname } from "node:path";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "./version.js";
-import { exportTelemetry } from "../telemetry.js";
-import {
-  checkForUpdate,
-  performUpdate,
-  isNpmInstall,
-  getCurrentExecutablePath,
-} from "./updater.js";
+import { exportTelemetry } from "../telemetry/index.js";
+import { checkForUpdate, performUpdate, isNpmInstall } from "./updater.js";
+import { getCurrentExecutablePath } from "./executable.js";
 import { confirm } from "./prompts.js";
 import { removeFromPath } from "./shell.js";
 

--- a/src/cli/executable.test.ts
+++ b/src/cli/executable.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for executable detection.
+ *
+ * `isCompiledBinary` gates self-update: only the Bun-compiled standalone binary
+ * may update itself. Running from source (tsx/node) or via the bun interpreter
+ * must report false so it never downloads and re-execs a binary.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { isCompiledBinary, getCurrentExecutablePath } from "./executable.js";
+
+const ORIGINAL_EXEC_PATH = process.execPath;
+const ORIGINAL_ARGV1 = process.argv[1];
+
+const setExecPath = (value: string): void => {
+  Object.defineProperty(process, "execPath", { value, configurable: true });
+};
+
+afterEach(() => {
+  Object.defineProperty(process, "execPath", { value: ORIGINAL_EXEC_PATH, configurable: true });
+  process.argv[1] = ORIGINAL_ARGV1;
+});
+
+describe("isCompiledBinary", () => {
+  it("is false when running via the node interpreter (e.g. tsx src/index.ts)", () => {
+    setExecPath("/usr/local/bin/node");
+    expect(isCompiledBinary()).toBe(false);
+  });
+
+  it("is false when running via the bun interpreter", () => {
+    setExecPath("/Users/me/.bun/bin/bun");
+    expect(isCompiledBinary()).toBe(false);
+  });
+
+  it("is true when execPath is the standalone binary itself", () => {
+    setExecPath("/Users/me/Library/Application Support/pcb-lens/bin/pcb-lens");
+    expect(isCompiledBinary()).toBe(true);
+  });
+});
+
+describe("getCurrentExecutablePath", () => {
+  it("returns argv[1] (the script) when running under an interpreter", () => {
+    setExecPath("/usr/local/bin/node");
+    process.argv[1] = "/repo/src/index.ts";
+    expect(getCurrentExecutablePath()).toBe("/repo/src/index.ts");
+  });
+
+  it("returns execPath (the binary) for a compiled binary", () => {
+    const bin = "/opt/pcb-lens/bin/pcb-lens";
+    setExecPath(bin);
+    expect(getCurrentExecutablePath()).toBe(bin);
+  });
+});

--- a/src/cli/executable.ts
+++ b/src/cli/executable.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for locating the running CLI executable.
+ */
+
+/**
+ * Get the path to the current executable.
+ *
+ * For Bun-compiled binaries, `process.execPath` points to the binary itself.
+ * For Node.js, `process.argv[1]` is the script path.
+ */
+export const getCurrentExecutablePath = (): string => {
+  if (process.execPath.includes("node") || process.execPath.includes("bun")) {
+    // Running via node/bun interpreter - use argv[1]
+    return process.argv[1];
+  }
+  // Compiled binary - use execPath
+  return process.execPath;
+};
+
+/**
+ * Whether the process is running as a Bun-compiled standalone binary.
+ *
+ * Running from source via the `node`/`bun`/`tsx` interpreter leaves
+ * `process.execPath` pointing at that interpreter; a compiled binary's
+ * `execPath` is the binary itself. Only the compiled binary should ever
+ * self-update.
+ */
+export const isCompiledBinary = (): boolean =>
+  !process.execPath.includes("node") && !process.execPath.includes("bun");

--- a/src/cli/updater.test.ts
+++ b/src/cli/updater.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the auto-update startup guard.
+ *
+ * Regression: running from source (tsx/node) used to fall through the
+ * npm-install guard and perform a live GitHub update check, which could
+ * download a binary and re-exec into it. `autoUpdate` must now no-op (and
+ * touch the network) only for the compiled standalone binary.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { autoUpdate } from "./updater.js";
+
+const ORIGINAL_EXEC_PATH = process.execPath;
+const ORIGINAL_ARGV1 = process.argv[1];
+
+const setExecPath = (value: string): void => {
+  Object.defineProperty(process, "execPath", { value, configurable: true });
+};
+
+afterEach(() => {
+  Object.defineProperty(process, "execPath", { value: ORIGINAL_EXEC_PATH, configurable: true });
+  process.argv[1] = ORIGINAL_ARGV1;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("autoUpdate self-update guard", () => {
+  it("returns false and performs no network call when running from source (tsx/node)", async () => {
+    setExecPath("/usr/local/bin/node");
+    // argv[1] is the source entry, NOT a node_modules path: this isolates the
+    // isCompiledBinary guard from the separate npm-install guard.
+    process.argv[1] = "/Users/me/Developer/pcb-lens/src/index.ts";
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const updated = await autoUpdate();
+
+    expect(updated).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reaches the network update check only when running as the compiled binary", async () => {
+    // execPath is the binary itself, and argv[1] is not an npm-install path.
+    const bin = "/Users/me/Library/Application Support/pcb-lens/bin/pcb-lens";
+    setExecPath(bin);
+    process.argv[1] = bin;
+    const fetchSpy = vi.fn().mockRejectedValue(new Error("network disabled in test"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const updated = await autoUpdate();
+
+    // The network call failed, so no update is applied, but the guard let it
+    // get as far as fetch (proving the guard, not luck, is what gates updates).
+    expect(updated).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/updater.ts
+++ b/src/cli/updater.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "./version.js";
+import { getCurrentExecutablePath, isCompiledBinary } from "./executable.js";
 
 /** GitHub release information. */
 interface GitHubRelease {
@@ -189,20 +190,6 @@ const downloadFile = async (url: string, destPath: string): Promise<void> => {
 };
 
 /**
- * Get the path to the current executable.
- */
-export const getCurrentExecutablePath = (): string => {
-  // For Bun-compiled binaries, process.execPath points to the binary itself
-  // For Node.js, process.argv[1] is the script path
-  if (process.execPath.includes("node") || process.execPath.includes("bun")) {
-    // Running via node/bun interpreter - use argv[1]
-    return process.argv[1];
-  }
-  // Compiled binary - use execPath
-  return process.execPath;
-};
-
-/**
  * Generate a unique backup path with timestamp to avoid conflicts with locked files.
  * On Windows, previous backup files may still be locked by the old process.
  */
@@ -344,6 +331,12 @@ export const reexec = (): never => {
  * @returns true if an update was applied and process should restart
  */
 export const autoUpdate = async (): Promise<boolean> => {
+  // Only the compiled standalone binary self-updates. Running from source
+  // (tsx/node) must never download a binary and re-exec into it.
+  if (!isCompiledBinary()) {
+    return false;
+  }
+
   // Skip auto-update for npm installs - use npm update instead
   if (isNpmInstall()) {
     return false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import crypto from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { VERSION } from "./cli/version.js";
-import { initTelemetry } from "./telemetry.js";
+import { initTelemetry, initOtel } from "./telemetry/index.js";
 import { register as registerGetPcbMetadata } from "./tools/get-pcb-metadata.js";
 import { register as registerGetPcbComponent } from "./tools/get-pcb-component.js";
 import { register as registerGetPcbNet } from "./tools/get-pcb-net.js";
@@ -89,6 +89,8 @@ export const createServer = (): McpServer => {
  */
 export const runServer = async (): Promise<void> => {
   initTelemetry(crypto.randomUUID());
+  // Opt-in OpenTelemetry (no-op unless OTEL_* env is configured).
+  await initOtel({ serviceName: "pcb-lens", serviceVersion: VERSION });
   const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Telemetry public API.
+ *
+ * - `local`: fire-and-forget JSONL usage analytics written next to the install.
+ * - `otel`:  opt-in OpenTelemetry traces/metrics/logs (no-op unless OTEL_* env
+ *            is configured).
+ *
+ * Import telemetry from this barrel rather than the individual modules.
+ */
+export * from "./local.js";
+export * from "./otel.js";

--- a/src/telemetry/local.test.ts
+++ b/src/telemetry/local.test.ts
@@ -13,7 +13,7 @@ import {
   logToolEvent,
   withTelemetry,
   exportTelemetry,
-} from "./telemetry.js";
+} from "./local.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "telemetry-test-"));
 const testTelemetryPath = join(testDir, "telemetry.jsonl");

--- a/src/telemetry/local.ts
+++ b/src/telemetry/local.ts
@@ -9,7 +9,8 @@ import { appendFileSync, mkdirSync, existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { userInfo, hostname, platform, arch, release } from "node:os";
 import { execSync } from "node:child_process";
-import { VERSION } from "./cli/version.js";
+import { VERSION } from "../cli/version.js";
+import { instrumentTool } from "./otel.js";
 
 // =============================================================================
 // Types
@@ -150,7 +151,14 @@ export const withTelemetry = <T extends Record<string, unknown>, R>(
     const start = Date.now();
     let success = true;
     try {
-      const result = await handler(args);
+      // OpenTelemetry span/metrics/logs wrap the handler (no-op unless configured
+      // via OTEL_* env). The handler runs exactly once, inside the span.
+      const result = await instrumentTool(
+        toolName,
+        args as Record<string, unknown>,
+        () => handler(args),
+        { isErrorResult: isErrorContent }
+      );
       // Detect error results (objects with an "error" field in the text content)
       if (isErrorContent(result)) {
         success = false;

--- a/src/telemetry/otel.ts
+++ b/src/telemetry/otel.ts
@@ -1,0 +1,404 @@
+/**
+ * OpenTelemetry instrumentation (vendor-neutral, OTLP).
+ *
+ * Emits a span, metrics, and a structured log per tool call. Configured purely
+ * through the standard `OTEL_*` environment variables, so it works against any
+ * OTLP-compatible backend (Collector, Jaeger, Tempo, Honeycomb, Datadog, ...).
+ *
+ * Design constraints (see issue #66):
+ *  - Disabled by default. If no OTLP endpoint is configured the SDK is never
+ *    imported and `instrumentTool` is a pass-through with zero overhead.
+ *  - Telemetry must never break a tool call. Every span/metric/log operation is
+ *    wrapped so an exporter or SDK fault degrades to "no telemetry", never an
+ *    error returned to the caller.
+ *  - This module is shared verbatim across the MCP servers. Repo-specific values
+ *    (service name) are passed into `initOtel`; everything else comes from env.
+ *  - stdio transport owns stdout, so diagnostics are written to stderr only and
+ *    no console/stdout exporter is ever used.
+ */
+
+import { userInfo } from "node:os";
+import { trace, metrics, SpanStatusCode, type Span, type Attributes } from "@opentelemetry/api";
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+import type { PushMetricExporter } from "@opentelemetry/sdk-metrics";
+import type { LogRecordExporter } from "@opentelemetry/sdk-logs";
+
+const INSTRUMENTATION_NAME = "@intelligentelectron/mcp";
+
+// =============================================================================
+// Module state
+// =============================================================================
+
+/**
+ * True only after the SDK has successfully started. While false, `instrumentTool`
+ * is a pure pass-through (true zero overhead), so an unconfigured or failed
+ * setup costs nothing on the hot path.
+ */
+let enabled = false;
+
+/** The started SDK instance, retained so we can flush + shut it down on exit. */
+let sdk: { shutdown: () => Promise<void>; forceFlush?: () => Promise<void> } | undefined;
+
+/** Bun-only fallback timer that forces periodic metric export (see startMetricFlushFallback). */
+let metricFlushTimer: ReturnType<typeof setInterval> | undefined;
+
+/** The push metric reader, retained so the bun fallback can force a flush. */
+let metricReader: { forceFlush: () => Promise<void> } | undefined;
+
+interface Instruments {
+  calls: ReturnType<ReturnType<typeof metrics.getMeter>["createCounter"]>;
+  duration: ReturnType<ReturnType<typeof metrics.getMeter>["createHistogram"]>;
+  errors: ReturnType<ReturnType<typeof metrics.getMeter>["createCounter"]>;
+}
+let instruments: Instruments | undefined;
+
+// =============================================================================
+// Configuration helpers
+// =============================================================================
+
+/** Whether the standard env says telemetry should be on. */
+const isConfigured = (): boolean => {
+  if (isTruthy(process.env.OTEL_SDK_DISABLED)) return false;
+  // Opt in purely by pointing at an endpoint (general or any per-signal one).
+  return Boolean(
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+      process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ||
+      process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+  );
+};
+
+const isTruthy = (v: string | undefined): boolean =>
+  v === "1" || v?.toLowerCase() === "true";
+
+/** Write a diagnostic line to stderr only (never stdout, which carries MCP JSON-RPC). */
+const diagStderr = (msg: string): void => {
+  try {
+    process.stderr.write(`[otel] ${msg}\n`);
+  } catch {
+    // ignore
+  }
+};
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+/**
+ * Initialize OpenTelemetry if (and only if) the standard env vars request it.
+ * No-op and zero overhead otherwise. Safe to call exactly once at startup;
+ * never throws; a setup failure degrades to disabled telemetry.
+ */
+export const initOtel = async (opts: { serviceName: string; serviceVersion: string }): Promise<void> => {
+  if (enabled || !isConfigured()) return;
+
+  try {
+    // Heavy SDK is imported lazily so the disabled path never loads it.
+    const { NodeSDK } = await import("@opentelemetry/sdk-node");
+    const { PeriodicExportingMetricReader } = await import("@opentelemetry/sdk-metrics");
+    const { BatchLogRecordProcessor } = await import("@opentelemetry/sdk-logs");
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+    const { diag, DiagLogLevel } = await import("@opentelemetry/api");
+
+    // Route OTel's own diagnostics to stderr; never the default console logger,
+    // which would corrupt the stdio MCP stream on stdout.
+    diag.setLogger(
+      {
+        verbose: () => {},
+        debug: () => {},
+        info: () => {},
+        warn: (m: string) => diagStderr(m),
+        error: (m: string) => diagStderr(m),
+      },
+      DiagLogLevel.WARN
+    );
+
+    const { traceExporter, metricExporter, logExporter } = await createExporters();
+
+    // service.name from env wins; our value is only a fallback default.
+    // enduser.id is the host OS account, attributing this per-session process to
+    // whoever is running it. Set at the resource level so it tags traces,
+    // metrics, and logs alike.
+    const resource = resourceFromAttributes({
+      "service.name": process.env.OTEL_SERVICE_NAME || opts.serviceName,
+      "service.version": opts.serviceVersion,
+      ...hostEnduser(),
+    });
+
+    const reader = new PeriodicExportingMetricReader({ exporter: metricExporter });
+    metricReader = reader;
+
+    const nodeSdk = new NodeSDK({
+      resource,
+      traceExporter,
+      metricReaders: [reader],
+      logRecordProcessors: [new BatchLogRecordProcessor(logExporter)],
+    });
+
+    nodeSdk.start();
+    sdk = nodeSdk;
+    instruments = undefined; // rebind lazily to the now-registered MeterProvider
+    enabled = true;
+
+    startMetricFlushFallback();
+    installShutdownHooks();
+  } catch (err) {
+    // Telemetry setup must never take the server down.
+    diagStderr(`init failed, telemetry disabled: ${describeError(err)}`);
+    enabled = false;
+    sdk = undefined;
+  }
+};
+
+/**
+ * Select OTLP exporters per `OTEL_EXPORTER_OTLP_PROTOCOL`. Each exporter reads
+ * its own endpoint/headers/timeout from the standard env. Default is
+ * `http/protobuf` (the OTel default and the most portable for compiled
+ * binaries). `grpc` is not bundled in the standalone binaries, so it falls
+ * back to `http/protobuf` with a warning.
+ */
+const createExporters = async (): Promise<{
+  traceExporter: SpanExporter;
+  metricExporter: PushMetricExporter;
+  logExporter: LogRecordExporter;
+}> => {
+  const protocol = (
+    process.env.OTEL_EXPORTER_OTLP_PROTOCOL || "http/protobuf"
+  ).toLowerCase();
+
+  if (protocol === "grpc") {
+    diagStderr("OTEL_EXPORTER_OTLP_PROTOCOL=grpc is not supported here; using http/protobuf");
+  }
+
+  if (protocol === "http/json") {
+    const t = await import("@opentelemetry/exporter-trace-otlp-http");
+    const m = await import("@opentelemetry/exporter-metrics-otlp-http");
+    const l = await import("@opentelemetry/exporter-logs-otlp-http");
+    return {
+      traceExporter: new t.OTLPTraceExporter(),
+      metricExporter: new m.OTLPMetricExporter(),
+      logExporter: new l.OTLPLogExporter(),
+    };
+  }
+
+  // http/protobuf (default) and grpc-fallback
+  const t = await import("@opentelemetry/exporter-trace-otlp-proto");
+  const m = await import("@opentelemetry/exporter-metrics-otlp-proto");
+  const l = await import("@opentelemetry/exporter-logs-otlp-proto");
+  return {
+    traceExporter: new t.OTLPTraceExporter(),
+    metricExporter: new m.OTLPMetricExporter(),
+    logExporter: new l.OTLPLogExporter(),
+  };
+};
+
+/**
+ * Bun's compiled standalone runtime does not fire the metric reader's internal
+ * `unref()`'d interval, so periodic metric export never happens there and a
+ * long-running server would only emit metrics on shutdown. Under bun, drive an
+ * explicit flush on our own (ref'd) timer at the configured export interval.
+ * No-op on Node, where the reader's own interval works. Cleared on shutdown.
+ */
+const startMetricFlushFallback = (): void => {
+  if (!(process.versions as { bun?: string }).bun) return;
+  const intervalMs = Number(process.env.OTEL_METRIC_EXPORT_INTERVAL) || 60000;
+  metricFlushTimer = setInterval(() => {
+    void metricReader?.forceFlush?.();
+  }, intervalMs);
+};
+
+let shutdownHooksInstalled = false;
+const installShutdownHooks = (): void => {
+  if (shutdownHooksInstalled) return;
+  shutdownHooksInstalled = true;
+  const onSignal = (signal: NodeJS.Signals) => {
+    void shutdownOtel().finally(() => {
+      // Re-raise default behavior so the process actually exits.
+      process.kill(process.pid, signal);
+    });
+  };
+  process.once("SIGTERM", onSignal);
+  process.once("SIGINT", onSignal);
+  process.once("beforeExit", () => {
+    void shutdownOtel();
+  });
+};
+
+/**
+ * Flush and shut down the SDK. Important for short-lived / CLI invocations so
+ * batched, async exports are not lost on exit. Idempotent and never throws.
+ */
+export const shutdownOtel = async (): Promise<void> => {
+  if (metricFlushTimer) {
+    clearInterval(metricFlushTimer);
+    metricFlushTimer = undefined;
+  }
+  metricReader = undefined;
+  const active = sdk;
+  if (!active) return;
+  sdk = undefined;
+  enabled = false;
+  try {
+    await active.shutdown();
+  } catch (err) {
+    diagStderr(`shutdown error: ${describeError(err)}`);
+  }
+};
+
+
+// =============================================================================
+// Per-tool-call instrumentation
+// =============================================================================
+
+/**
+ * Wrap a single tool invocation in a span named `tool/<name>`, record the
+ * standard metrics, and emit a structured log correlated by trace/span id.
+ *
+ * `run` is executed exactly once. When telemetry is disabled this is a direct
+ * pass-through. Telemetry never alters the result and never throws on its own.
+ */
+export const instrumentTool = async <R>(
+  toolName: string,
+  args: Record<string, unknown>,
+  run: () => Promise<R>,
+  opts?: { isErrorResult?: (result: R) => boolean }
+): Promise<R> => {
+  if (!enabled) return run();
+
+  const tracer = trace.getTracer(INSTRUMENTATION_NAME);
+  return tracer.startActiveSpan(`tool/${toolName}`, async (span) => {
+    const start = Date.now();
+    try {
+      safely(() => {
+        span.setAttribute("tool.name", toolName);
+        if (isTruthy(process.env.OTEL_CAPTURE_TOOL_ARGS)) {
+          // Full args, untruncated: tool-call arguments are inherently small.
+          span.setAttribute("tool.args", safeJson(args));
+        }
+      });
+
+      const result = await run();
+
+      const isError = opts?.isErrorResult?.(result) ?? false;
+      finishSpan(span, toolName, isError ? "error" : "success", isError ? "tool_error" : undefined, Date.now() - start);
+      return result;
+    } catch (err) {
+      const errorType = err instanceof Error ? err.name : "Error";
+      safely(() => span.recordException(err instanceof Error ? err : new Error(String(err))));
+      finishSpan(span, toolName, "error", errorType, Date.now() - start);
+      throw err;
+    }
+  });
+};
+
+const finishSpan = (
+  span: Span,
+  toolName: string,
+  outcome: "success" | "error",
+  errorType: string | undefined,
+  durationMs: number
+): void => {
+  safely(() => {
+    span.setAttribute("tool.outcome", outcome);
+    span.setAttribute("tool.duration_ms", durationMs);
+    if (errorType) span.setAttribute("error.type", errorType);
+    span.setStatus({ code: outcome === "error" ? SpanStatusCode.ERROR : SpanStatusCode.OK });
+  });
+
+  safely(() => {
+    const inst = getInstruments();
+    const labels: Attributes = { tool: toolName, outcome };
+    inst.calls.add(1, labels);
+    inst.duration.record(durationMs, labels);
+    if (outcome === "error") {
+      inst.errors.add(1, { tool: toolName, error_type: errorType ?? "unknown" });
+    }
+  });
+
+  safely(() => emitLog(span, toolName, outcome, errorType, durationMs));
+
+  safely(() => span.end());
+};
+
+const emitLog = (
+  span: Span,
+  toolName: string,
+  outcome: "success" | "error",
+  errorType: string | undefined,
+  durationMs: number
+): void => {
+  const sc = span.spanContext();
+  const logger = logs.getLogger(INSTRUMENTATION_NAME);
+  logger.emit({
+    severityNumber: outcome === "error" ? SeverityNumber.ERROR : SeverityNumber.INFO,
+    severityText: outcome === "error" ? "ERROR" : "INFO",
+    body: `tool/${toolName} ${outcome}`,
+    attributes: {
+      "tool.name": toolName,
+      "tool.outcome": outcome,
+      "tool.duration_ms": durationMs,
+      ...(errorType ? { "error.type": errorType } : {}),
+      // Explicit ids for trace-to-log correlation in addition to the record's
+      // own trace context.
+      trace_id: sc.traceId,
+      span_id: sc.spanId,
+    },
+  });
+};
+
+const getInstruments = (): Instruments => {
+  if (!instruments) {
+    const meter = metrics.getMeter(INSTRUMENTATION_NAME);
+    instruments = {
+      calls: meter.createCounter("tool.calls", {
+        description: "Number of tool invocations",
+      }),
+      duration: meter.createHistogram("tool.duration", {
+        unit: "ms",
+        description: "Tool invocation duration in milliseconds",
+      }),
+      errors: meter.createCounter("tool.errors", {
+        description: "Number of failed tool invocations",
+      }),
+    };
+  }
+  return instruments;
+};
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * The host OS account name as an `enduser.id` resource attribute, attributing
+ * this per-session process to whoever runs it. Best-effort: returns an empty
+ * object if the username can't be read, so telemetry setup never fails on it.
+ */
+const hostEnduser = (): Record<string, string> => {
+  try {
+    const name = userInfo().username;
+    return name ? { "enduser.id": name } : {};
+  } catch {
+    return {};
+  }
+};
+
+/** Run a telemetry side effect, swallowing any error so it can't break a tool. */
+const safely = (fn: () => void): void => {
+  try {
+    fn();
+  } catch {
+    // telemetry must never throw into the caller
+  }
+};
+
+const safeJson = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+};
+
+const describeError = (err: unknown): string => (err instanceof Error ? err.message : String(err));

--- a/src/telemetry/otel.ts
+++ b/src/telemetry/otel.ts
@@ -63,14 +63,13 @@ const isConfigured = (): boolean => {
   // Opt in purely by pointing at an endpoint (general or any per-signal one).
   return Boolean(
     process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
-      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
-      process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ||
-      process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ||
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
   );
 };
 
-const isTruthy = (v: string | undefined): boolean =>
-  v === "1" || v?.toLowerCase() === "true";
+const isTruthy = (v: string | undefined): boolean => v === "1" || v?.toLowerCase() === "true";
 
 /** Write a diagnostic line to stderr only (never stdout, which carries MCP JSON-RPC). */
 const diagStderr = (msg: string): void => {
@@ -90,7 +89,10 @@ const diagStderr = (msg: string): void => {
  * No-op and zero overhead otherwise. Safe to call exactly once at startup;
  * never throws; a setup failure degrades to disabled telemetry.
  */
-export const initOtel = async (opts: { serviceName: string; serviceVersion: string }): Promise<void> => {
+export const initOtel = async (opts: {
+  serviceName: string;
+  serviceVersion: string;
+}): Promise<void> => {
   if (enabled || !isConfigured()) return;
 
   try {
@@ -163,9 +165,7 @@ const createExporters = async (): Promise<{
   metricExporter: PushMetricExporter;
   logExporter: LogRecordExporter;
 }> => {
-  const protocol = (
-    process.env.OTEL_EXPORTER_OTLP_PROTOCOL || "http/protobuf"
-  ).toLowerCase();
+  const protocol = (process.env.OTEL_EXPORTER_OTLP_PROTOCOL || "http/protobuf").toLowerCase();
 
   if (protocol === "grpc") {
     diagStderr("OTEL_EXPORTER_OTLP_PROTOCOL=grpc is not supported here; using http/protobuf");
@@ -246,7 +246,6 @@ export const shutdownOtel = async (): Promise<void> => {
   }
 };
 
-
 // =============================================================================
 // Per-tool-call instrumentation
 // =============================================================================
@@ -281,7 +280,13 @@ export const instrumentTool = async <R>(
       const result = await run();
 
       const isError = opts?.isErrorResult?.(result) ?? false;
-      finishSpan(span, toolName, isError ? "error" : "success", isError ? "tool_error" : undefined, Date.now() - start);
+      finishSpan(
+        span,
+        toolName,
+        isError ? "error" : "success",
+        isError ? "tool_error" : undefined,
+        Date.now() - start
+      );
       return result;
     } catch (err) {
       const errorType = err instanceof Error ? err.name : "Error";

--- a/src/tools/export-cadence-constraints.ts
+++ b/src/tools/export-cadence-constraints.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { detectCadenceInstalls, requireWindows, serializeCadenceCall } from "./lib/cadence.js";
 import type { ErrorResult, ExportCadenceConstraintsResult } from "./lib/types.js";
 import { formatResult } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 const execAsync = promisify(exec);
 

--- a/src/tools/export-cadence-ipc2581.ts
+++ b/src/tools/export-cadence-ipc2581.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { detectCadenceInstalls, requireWindows, serializeCadenceCall } from "./lib/cadence.js";
 import type { ErrorResult, ExportCadenceBoardResult } from "./lib/types.js";
 import { formatResult } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 const execAsync = promisify(exec);
 

--- a/src/tools/get-constraints.ts
+++ b/src/tools/get-constraints.ts
@@ -12,7 +12,7 @@ import type {
   ErrorResult,
 } from "./lib/types.js";
 import { formatResult } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 // =============================================================================
 // File validation

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -17,7 +17,7 @@ import {
   formatResult,
   validateFile,
 } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 export const queryComponent = async (
   filePath: string,

--- a/src/tools/get-pcb-metadata.ts
+++ b/src/tools/get-pcb-metadata.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { DesignOverview, ErrorResult, LayerInfo, SectionInfo } from "./lib/types.js";
 import { attr, streamAllLines } from "./lib/xml-utils.js";
 import { formatResult, validateFile } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 export const getDesignOverview = async (
   filePath: string

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -20,7 +20,7 @@ import {
   validatePattern,
   type NetAccumulator,
 } from "./shared.js";
-import { withTelemetry } from "../telemetry.js";
+import { withTelemetry } from "../telemetry/index.js";
 
 export const queryNet = async (
   filePath: string,

--- a/test/otel/bun-entry.ts
+++ b/test/otel/bun-entry.ts
@@ -1,0 +1,19 @@
+/**
+ * Standalone entry used only to validate that the OpenTelemetry stack bundles and
+ * runs inside a `bun build --compile` standalone binary (the riskiest part of
+ * shipping OTel in these servers). It initializes telemetry, emits one
+ * instrumented call, flushes, and exits. Drive it with OTEL_* env pointed at a
+ * receiver; the binary should deliver a span/metric/log and exit 0.
+ */
+import { initOtel, instrumentTool, shutdownOtel } from "../../src/telemetry/index.js";
+
+const main = async (): Promise<void> => {
+  await initOtel({ serviceName: "bun-smoke", serviceVersion: "0.0.0" });
+  await instrumentTool("smoke_tool", { hello: "world" }, async () => ({
+    content: [{ type: "text", text: "ok" }],
+  }));
+  await shutdownOtel();
+  process.stderr.write("[bun-entry] done\n");
+};
+
+void main();

--- a/test/otel/bun-smoke-runner.ts
+++ b/test/otel/bun-smoke-runner.ts
@@ -46,8 +46,14 @@ const run = async (): Promise<void> => {
   const span = receiver.spans().find((s) => s.name === "tool/smoke_tool");
   console.log("binary exit code:", exitCode);
   console.log("span delivered:  ", Boolean(span), span?.attributes["tool.outcome"]);
-  console.log("metric delivered:", receiver.metrics().some((m) => m.name === "tool.calls"));
-  console.log("log delivered:   ", receiver.logs().some((l) => l.body === "tool/smoke_tool success"));
+  console.log(
+    "metric delivered:",
+    receiver.metrics().some((m) => m.name === "tool.calls")
+  );
+  console.log(
+    "log delivered:   ",
+    receiver.logs().some((l) => l.body === "tool/smoke_tool success")
+  );
 
   if (exitCode !== 0 || !ok) {
     console.error("FAIL: OTel did not work inside the bun-compiled binary");

--- a/test/otel/bun-smoke-runner.ts
+++ b/test/otel/bun-smoke-runner.ts
@@ -1,0 +1,59 @@
+/**
+ * Runner for the Bun-compiled OTel bundling gate.
+ *
+ * Starts the in-process OTLP receiver, runs the pre-compiled `bin/otel-bun-smoke`
+ * binary against it, and asserts that a span, a metric, and a log were delivered
+ * from inside the standalone binary. Exits non-zero on failure.
+ *
+ * Usage:
+ *   bun build --compile test/otel/bun-entry.ts --outfile bin/otel-bun-smoke
+ *   npx tsx test/otel/bun-smoke-runner.ts
+ */
+import { spawn } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { OtlpReceiver, waitFor } from "./otlp-receiver.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BINARY = join(HERE, "..", "..", "bin", "otel-bun-smoke");
+
+const run = async (): Promise<void> => {
+  const receiver = new OtlpReceiver();
+  await receiver.start();
+
+  const child = spawn(BINARY, [], {
+    env: {
+      ...process.env,
+      OTEL_EXPORTER_OTLP_ENDPOINT: receiver.endpoint,
+      OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
+      OTEL_SERVICE_NAME: "bun-smoke",
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  const exitCode: number = await new Promise((resolve) => child.on("exit", (c) => resolve(c ?? 1)));
+
+  const ok = await waitFor(
+    () =>
+      receiver.spans().some((s) => s.name === "tool/smoke_tool") &&
+      receiver.metrics().some((m) => m.name === "tool.calls") &&
+      receiver.logs().some((l) => l.body === "tool/smoke_tool success"),
+    5000
+  );
+
+  await receiver.stop();
+
+  const span = receiver.spans().find((s) => s.name === "tool/smoke_tool");
+  console.log("binary exit code:", exitCode);
+  console.log("span delivered:  ", Boolean(span), span?.attributes["tool.outcome"]);
+  console.log("metric delivered:", receiver.metrics().some((m) => m.name === "tool.calls"));
+  console.log("log delivered:   ", receiver.logs().some((l) => l.body === "tool/smoke_tool success"));
+
+  if (exitCode !== 0 || !ok) {
+    console.error("FAIL: OTel did not work inside the bun-compiled binary");
+    process.exit(1);
+  }
+  console.log("PASS: OTel spans/metrics/logs exported from a bun-compiled binary");
+};
+
+void run();

--- a/test/otel/e2e.test.ts
+++ b/test/otel/e2e.test.ts
@@ -112,7 +112,10 @@ describe("OpenTelemetry end-to-end", () => {
         () =>
           receiver
             .spans()
-            .some((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success") &&
+            .some(
+              (s) =>
+                s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success"
+            ) &&
           receiver.metrics().some((m) => m.name === "tool.calls") &&
           receiver.logs().some((l) => l.body === "tool/get_pcb_metadata success")
       );
@@ -120,7 +123,9 @@ describe("OpenTelemetry end-to-end", () => {
 
       const span = receiver
         .spans()
-        .find((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success")!;
+        .find(
+          (s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success"
+        )!;
       expect(span.attributes["tool.name"]).toBe("get_pcb_metadata");
       expect(typeof span.attributes["tool.duration_ms"]).toBe("number");
 
@@ -159,13 +164,17 @@ describe("OpenTelemetry end-to-end", () => {
       const got = await waitFor(() =>
         receiver
           .spans()
-          .some((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error")
+          .some(
+            (s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error"
+          )
       );
       expect(got).toBe(true);
 
       const span = receiver
         .spans()
-        .find((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error")!;
+        .find(
+          (s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error"
+        )!;
       expect(span.attributes["error.type"]).toBeDefined();
 
       await waitFor(() => receiver.metrics().some((m) => m.name === "tool.errors"));

--- a/test/otel/e2e.test.ts
+++ b/test/otel/e2e.test.ts
@@ -1,0 +1,223 @@
+/**
+ * End-to-end OpenTelemetry validation.
+ *
+ * Spawns the real MCP server over stdio (via the MCP client SDK), points it at an
+ * in-process OTLP receiver, calls tools, and asserts the emitted spans, metrics,
+ * and logs. Covers the issue #66 acceptance criteria:
+ *   - no-op + no emission when unconfigured
+ *   - per-tool-call span (tool/<name>) with outcome attributes
+ *   - tool.calls / tool.duration / tool.errors metrics
+ *   - structured log correlated by trace/span id
+ *   - failure path: outcome=error, tool result still returned
+ *   - exporter unreachable: tool calls still succeed
+ *   - flush on shutdown
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir, userInfo } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { OtlpReceiver, waitFor } from "./otlp-receiver.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SERVER_ENTRY = join(HERE, "server-entry.ts");
+const REPO_ROOT = join(HERE, "..", "..");
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "testcase3-RevC.xml");
+const HAS_FIXTURE = existsSync(FIXTURE);
+const TEST_TIMEOUT = 30_000;
+
+/** A scratch telemetry path so the JSONL logger never touches the real install dir. */
+const scratchTelemetry = () => join(mkdtempSync(join(tmpdir(), "pl-otel-")), "telemetry.jsonl");
+
+/** Spawn the server with the given env, run `fn`, then close the client. */
+const withServer = async (
+  env: Record<string, string>,
+  fn: (client: Client) => Promise<void>
+): Promise<void> => {
+  const transport = new StdioClientTransport({
+    command: process.execPath, // node
+    args: ["--import", "tsx", SERVER_ENTRY],
+    cwd: REPO_ROOT,
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      PCB_LENS_TELEMETRY_PATH: scratchTelemetry(),
+      ...env,
+    },
+  });
+  const client = new Client({ name: "otel-e2e", version: "1.0.0" }, { capabilities: {} });
+  await client.connect(transport);
+  try {
+    await fn(client);
+  } finally {
+    await client.close();
+  }
+};
+
+const otelEnv = (receiver: OtlpReceiver, extra: Record<string, string> = {}) => ({
+  OTEL_EXPORTER_OTLP_ENDPOINT: receiver.endpoint,
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
+  OTEL_SERVICE_NAME: "test-pcb-lens",
+  // Flush quickly so assertions don't wait on long default batch windows.
+  OTEL_BSP_SCHEDULE_DELAY: "200",
+  OTEL_BLRP_SCHEDULE_DELAY: "200",
+  OTEL_METRIC_EXPORT_INTERVAL: "400",
+  ...extra,
+});
+
+describe("OpenTelemetry end-to-end", () => {
+  let receiver: OtlpReceiver;
+
+  beforeAll(async () => {
+    receiver = new OtlpReceiver();
+    await receiver.start();
+  });
+
+  afterAll(async () => {
+    await receiver.stop();
+  });
+
+  test(
+    "no-op: nothing is emitted when OTEL_* is not configured",
+    async () => {
+      const before = receiver.traceEnvelopes.length;
+      await withServer({}, async (client) => {
+        // Any call exercises the wrapper; result content is irrelevant here.
+        await client.callTool({
+          name: "get_pcb_metadata",
+          arguments: { file: "/nonexistent/none.xml" },
+        });
+      });
+      await new Promise((r) => setTimeout(r, 500));
+      expect(receiver.traceEnvelopes.length).toBe(before);
+    },
+    TEST_TIMEOUT
+  );
+
+  test.skipIf(!HAS_FIXTURE)(
+    "happy path: span + metrics + correlated log for a successful tool call",
+    async () => {
+      await withServer(otelEnv(receiver), async (client) => {
+        const res: any = await client.callTool({
+          name: "get_pcb_metadata",
+          arguments: { file: FIXTURE },
+        });
+        expect(res.isError).toBeFalsy();
+      });
+
+      const got = await waitFor(
+        () =>
+          receiver
+            .spans()
+            .some((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success") &&
+          receiver.metrics().some((m) => m.name === "tool.calls") &&
+          receiver.logs().some((l) => l.body === "tool/get_pcb_metadata success")
+      );
+      expect(got).toBe(true);
+
+      const span = receiver
+        .spans()
+        .find((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "success")!;
+      expect(span.attributes["tool.name"]).toBe("get_pcb_metadata");
+      expect(typeof span.attributes["tool.duration_ms"]).toBe("number");
+
+      const calls = receiver.metrics().find((m) => m.name === "tool.calls")!;
+      expect(
+        calls.points.some(
+          (p) => p.attributes.tool === "get_pcb_metadata" && p.attributes.outcome === "success"
+        )
+      ).toBe(true);
+      expect(receiver.metrics().some((m) => m.name === "tool.duration")).toBe(true);
+
+      const log = receiver.logs().find((l) => l.body === "tool/get_pcb_metadata success")!;
+      expect(log.attributes.trace_id).toBe(span.traceId);
+      expect(log.attributes.span_id).toBe(span.spanId);
+
+      // enduser.id is the host OS account, set at the resource level.
+      expect(receiver.resourceAttributes()["enduser.id"]).toBe(userInfo().username);
+    },
+    TEST_TIMEOUT
+  );
+
+  test(
+    "failure path: outcome=error span + error metric, tool result still returned",
+    async () => {
+      let toolReturned = false;
+      await withServer(otelEnv(receiver), async (client) => {
+        const res: any = await client.callTool({
+          name: "get_pcb_metadata",
+          arguments: { file: "/nonexistent/does-not-exist.xml" },
+        });
+        toolReturned = true;
+        expect(res).toBeDefined();
+      });
+      expect(toolReturned).toBe(true);
+
+      const got = await waitFor(() =>
+        receiver
+          .spans()
+          .some((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error")
+      );
+      expect(got).toBe(true);
+
+      const span = receiver
+        .spans()
+        .find((s) => s.name === "tool/get_pcb_metadata" && s.attributes["tool.outcome"] === "error")!;
+      expect(span.attributes["error.type"]).toBeDefined();
+
+      await waitFor(() => receiver.metrics().some((m) => m.name === "tool.errors"));
+      expect(receiver.metrics().some((m) => m.name === "tool.errors")).toBe(true);
+    },
+    TEST_TIMEOUT
+  );
+
+  test(
+    "reliability: an unreachable exporter never breaks a tool call",
+    async () => {
+      await withServer(
+        {
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:1",
+          OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
+          OTEL_BSP_SCHEDULE_DELAY: "200",
+        },
+        async (client) => {
+          const res: any = await client.callTool({
+            name: "get_pcb_metadata",
+            arguments: { file: "/nonexistent/none.xml" },
+          });
+          // The call resolves regardless of telemetry export failure.
+          expect(res).toBeDefined();
+          expect(res.content?.[0]?.text?.length ?? 0).toBeGreaterThan(0);
+        }
+      );
+    },
+    TEST_TIMEOUT
+  );
+
+  test(
+    "flush on shutdown: spans deferred by a long batch window still export on exit",
+    async () => {
+      const before = receiver.spans().length;
+      await withServer(
+        otelEnv(receiver, {
+          OTEL_BSP_SCHEDULE_DELAY: "600000",
+          OTEL_BLRP_SCHEDULE_DELAY: "600000",
+          OTEL_METRIC_EXPORT_INTERVAL: "600000",
+          OTEL_SERVICE_NAME: "test-flush",
+        }),
+        async (client) => {
+          await client.callTool({
+            name: "get_pcb_metadata",
+            arguments: { file: "/nonexistent/none.xml" },
+          });
+        }
+      );
+      const flushed = await waitFor(() => receiver.spans().length > before);
+      expect(flushed).toBe(true);
+    },
+    TEST_TIMEOUT
+  );
+});

--- a/test/otel/otlp-receiver.ts
+++ b/test/otel/otlp-receiver.ts
@@ -1,0 +1,197 @@
+/**
+ * Minimal in-process OTLP/HTTP (JSON) receiver for end-to-end telemetry tests.
+ *
+ * Listens on an ephemeral port and captures the OTLP export envelopes the MCP
+ * server sends for traces, metrics, and logs. Hermetic: no Docker, no real
+ * collector. Tests point the server at it via:
+ *
+ *   OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:<port>
+ *   OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+ */
+
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+
+/** A decoded OTLP attribute value (only the subset we assert on). */
+type AnyValue = {
+  stringValue?: string;
+  intValue?: string | number;
+  doubleValue?: number;
+  boolValue?: boolean;
+};
+
+export interface CapturedSpan {
+  name: string;
+  traceId: string;
+  spanId: string;
+  attributes: Record<string, string | number | boolean>;
+  status?: { code?: number };
+}
+
+export interface CapturedMetric {
+  name: string;
+  /** Flattened data points with their decoded attributes and value. */
+  points: Array<{ attributes: Record<string, string | number | boolean>; value: number }>;
+}
+
+export interface CapturedLog {
+  body?: string;
+  severityText?: string;
+  attributes: Record<string, string | number | boolean>;
+}
+
+const decodeAttrs = (
+  attrs: Array<{ key: string; value: AnyValue }> | undefined
+): Record<string, string | number | boolean> => {
+  const out: Record<string, string | number | boolean> = {};
+  for (const a of attrs ?? []) {
+    const v = a.value ?? {};
+    if (v.stringValue !== undefined) out[a.key] = v.stringValue;
+    else if (v.intValue !== undefined) out[a.key] = Number(v.intValue);
+    else if (v.doubleValue !== undefined) out[a.key] = v.doubleValue;
+    else if (v.boolValue !== undefined) out[a.key] = v.boolValue;
+  }
+  return out;
+};
+
+export class OtlpReceiver {
+  private server: Server | undefined;
+  readonly traceEnvelopes: unknown[] = [];
+  readonly metricEnvelopes: unknown[] = [];
+  readonly logEnvelopes: unknown[] = [];
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c as Buffer));
+      req.on("end", () => {
+        try {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+          if (req.url?.endsWith("/v1/traces")) this.traceEnvelopes.push(body);
+          else if (req.url?.endsWith("/v1/metrics")) this.metricEnvelopes.push(body);
+          else if (req.url?.endsWith("/v1/logs")) this.logEnvelopes.push(body);
+        } catch {
+          // ignore malformed bodies
+        }
+        // OTLP/HTTP expects a 200 with a (possibly empty) export response.
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) => this.server!.listen(0, "127.0.0.1", resolve));
+  }
+
+  get port(): number {
+    return (this.server!.address() as AddressInfo).port;
+  }
+
+  get endpoint(): string {
+    return `http://127.0.0.1:${this.port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+    this.server = undefined;
+  }
+
+  // --- Flattened accessors -------------------------------------------------
+
+  spans(): CapturedSpan[] {
+    const out: CapturedSpan[] = [];
+    for (const env of this.traceEnvelopes as Array<{ resourceSpans?: any[] }>) {
+      for (const rs of env.resourceSpans ?? []) {
+        for (const ss of rs.scopeSpans ?? []) {
+          for (const s of ss.spans ?? []) {
+            out.push({
+              name: s.name,
+              traceId: s.traceId,
+              spanId: s.spanId,
+              attributes: decodeAttrs(s.attributes),
+              status: s.status,
+            });
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  metrics(): CapturedMetric[] {
+    const out: CapturedMetric[] = [];
+    for (const env of this.metricEnvelopes as Array<{ resourceMetrics?: any[] }>) {
+      for (const rm of env.resourceMetrics ?? []) {
+        for (const sm of rm.scopeMetrics ?? []) {
+          for (const m of sm.metrics ?? []) {
+            const dps = m.sum?.dataPoints ?? m.histogram?.dataPoints ?? m.gauge?.dataPoints ?? [];
+            out.push({
+              name: m.name,
+              points: dps.map((dp: any) => ({
+                attributes: decodeAttrs(dp.attributes),
+                value:
+                  dp.asInt !== undefined
+                    ? Number(dp.asInt)
+                    : dp.asDouble !== undefined
+                      ? dp.asDouble
+                      : dp.count !== undefined
+                        ? Number(dp.count)
+                        : 0,
+              })),
+            });
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  logs(): CapturedLog[] {
+    const out: CapturedLog[] = [];
+    for (const env of this.logEnvelopes as Array<{ resourceLogs?: any[] }>) {
+      for (const rl of env.resourceLogs ?? []) {
+        for (const sl of rl.scopeLogs ?? []) {
+          for (const lr of sl.logRecords ?? []) {
+            out.push({
+              body: lr.body?.stringValue,
+              severityText: lr.severityText,
+              attributes: decodeAttrs(lr.attributes),
+            });
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Merged resource-level attributes across all captured trace/metric/log envelopes. */
+  resourceAttributes(): Record<string, string | number | boolean> {
+    const out: Record<string, string | number | boolean> = {};
+    const collect = (envs: unknown[], key: string): void => {
+      for (const env of envs as Array<
+        Record<string, Array<{ resource?: { attributes?: Parameters<typeof decodeAttrs>[0] } }>>
+      >) {
+        for (const r of env[key] ?? []) {
+          Object.assign(out, decodeAttrs(r.resource?.attributes));
+        }
+      }
+    };
+    collect(this.traceEnvelopes, "resourceSpans");
+    collect(this.metricEnvelopes, "resourceMetrics");
+    collect(this.logEnvelopes, "resourceLogs");
+    return out;
+  }
+}
+
+/** Poll until `predicate` is true or `timeoutMs` elapses. */
+export const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 8000,
+  intervalMs = 100
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return predicate();
+};

--- a/test/otel/server-entry.ts
+++ b/test/otel/server-entry.ts
@@ -1,0 +1,11 @@
+/**
+ * Test entry point: starts the real MCP server (stdio) without the CLI/auto-update
+ * wrapper in src/index.ts, so end-to-end telemetry tests run deterministically
+ * with no network calls. Exercises the real server.ts -> telemetry.ts -> otel.ts path.
+ */
+import { runServer } from "../../src/server.js";
+
+runServer().catch((err) => {
+  console.error("test server error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add vendor-neutral **OpenTelemetry**: per-tool-call span (`tool/<tool_name>`), metrics (`tool.calls`, `tool.duration`, `tool.errors`), and a structured log correlated by trace/span id, exported to any OTLP backend purely via standard `OTEL_*` env. Disabled and zero-overhead unless an endpoint is configured.
- Tag all telemetry with `enduser.id` from the host OS account name (per-session user) at the resource level, so it lands on traces, metrics, and logs. Opt-in raw arg capture via `OTEL_CAPTURE_TOOL_ARGS=1` (off by default).
- Consolidate telemetry into `src/telemetry/` (local JSONL `local` + OpenTelemetry `otel` behind a barrel).
- Fix: self-update now runs only for the compiled binary; running from source (tsx/node) no longer performs a GitHub update check or re-execs into a downloaded binary.
- Bump to **1.0.0** (first stable release).

## Test plan

- [x] `npm run type-check`, `npm run lint`, `npm test` (151 passing, incl. OTel e2e + auto-update guard tests)
- [x] OTel e2e against an in-process OTLP receiver: span + metrics + correlated log; `enduser.id` == host username; failure path; unreachable-exporter never breaks a call; flush on shutdown
- [x] Verified on the bun-compiled binary: traces/metrics/logs export, metrics push on the periodic interval, `enduser.id` present