### PR TITLE
docs: add research plans for reading proprietary PCB formats; track plans/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,8 @@ coverage/
 *.tmp
 *.temp
 
-# Private files and plans
+# Private files
 private/
-.plans/
 
 # Test fixtures (large XML/ZIP files downloaded via npm run setup)
 test/fixtures/*.xml

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,25 @@
+# Plans
+
+Research notes, design docs, and decision inputs for pcb-lens. Each entry is a living
+document; status reflects where the work stands as of the last edit.
+
+| Plan | Topic | Status |
+|---|---|---|
+| [allegro-brd-direct-read.md](allegro-brd-direct-read.md) | Read Cadence Allegro `.brd` binaries without the Windows/Cadence toolchain. KiCad 10's `pcbnew` importer is the one viable cross-platform path (layout + connectivity + constraints), invoked as an external process via the Python API (not `kicad-cli`); **stackup is not extracted** and stays on the IPC-2581/Cadence path. GPLv3 → separate-process boundary only. | Research |
+| [altium-pcbdoc-parser-research.md](altium-pcbdoc-parser-research.md) | Read Altium `.PcbDoc` files: OLE/CFB container (solved in JS via `js-cfb`) wrapping reverse-engineered `*6` record streams. No JS/TS reader exists; port source gated on AltiumSharp's license (KiCad/AtoK are GPLv3, reference-only). | Research |
+| [odbpp-parser-research.md](odbpp-parser-research.md) | Read ODB++ exports: data coverage is strong (stackup, netlist, geometry, constraints), but the gate is **licensing** — recommend a focused native TS parser against the free v8.1 spec rather than the AGPL `OdbDesign` core. | Research |
+| [ipc2581-layout-review.md](ipc2581-layout-review.md) | Original prototype plan: validate that IPC-2581 RevC XML is navigable enough for LLM-driven layout review with thin extraction tooling. The basis of the current pcb-lens tools. | Reference |
+
+## Conventions
+
+- One file per plan, kebab-case where practical.
+- Each plan opens with status/date and a **Bottom line** before the detail, explaining *why*
+  before *what*.
+- Plans stay in this folder until landed. After implementation, either delete the file (if
+  fully captured by code + commit history) or move to `docs/` if it has long-term reference
+  value.
+
+> Theme across the three parser-research docs (Allegro / Altium / ODB++): the technical
+> blocker is rarely data coverage — it is **licensing** (GPL/AGPL copyleft vs. pcb-lens's
+> Apache-2.0) and the **Cadence-export dependency** for design intent (constraints, stackup).
+> Each doc flags an empirical "validate on a real export first" step before any build.

--- a/plans/allegro-brd-direct-read.md
+++ b/plans/allegro-brd-direct-read.md
@@ -1,0 +1,154 @@
+# Reading Cadence Allegro .brd Files Directly — Open-Source Parser Research
+
+**Status:** Research / decision input · not yet scheduled
+**Date:** 2026-06-17
+**Goal:** Read Cadence Allegro `.brd` binary layout files *without* the Windows-only Cadence
+toolchain (extracta / IPC-2581 export), extracting layout (traces, vias, pads, components,
+placement), netlist/connectivity, design constraints/rules, and layer stackup — so the
+pcb-lens MCP server can drop its current `export_cadence_*` dependency that shells out to
+Allegro on Windows.
+
+## Bottom line
+
+There is exactly **one** mature, cross-platform, no-Cadence path to read the proprietary
+`.brd` binary: **KiCad 10's native Allegro importer** (`pcb_io_allegro.cpp` / the `pcbnew`
+`PCB_IO_MGR::ALLEGRO` plugin). It is fully reverse-engineered (no Cadence programs or
+libraries), runs on macOS/Linux, and extracts layout, connectivity, padstacks, and
+**physical constraint sets** (clearance, trace width, diff-pair gap → netclasses).
+
+Two hard limits decide how we use it:
+
+1. **Stackup gap.** The importer does **not** extract the dielectric stackup (per-layer
+   material, Dk, thickness, copper weight) — only copper-layer *ordering*. For real stackup
+   we still need an IPC-2581/extracta export (i.e. licensed Cadence). This is the #1 gap.
+2. **License.** KiCad is **GPLv3+**; pcb-lens is **Apache-2.0** on npm. We therefore **cannot
+   port or link** KiCad code in-process. The only clean route is to run KiCad as an **external
+   process** (same separate-process boundary we already accept for the Cadence shell-out) and
+   parse its open, text-based `.kicad_pcb` output.
+
+Net: KiCad 10 lets us move *layout + connectivity + constraints* to a cross-platform,
+no-Cadence path; **stackup stays on the Cadence/IPC-2581 path** until proven otherwise. A
+hybrid pipeline is the realistic target.
+
+## The one viable route: KiCad 10 `pcbnew` importer
+
+| Property | Finding |
+|---|---|
+| What it is | `PCB_IO_ALLEGRO` (`pcb_io_allegro.cpp`): binary PARSER phase (`ALLEGRO::PARSER::Parse` → `BRD_DB`) then BOARD_BUILDER (`BuildBoard` → KiCad `BOARD`). A real implementation, not a stub. |
+| Reverse-engineered | "reverse-engineered from the binary structure without using any Allegro programs or libraries" — no extracta, no IPC-2581, no Cadence runtime. |
+| Format detection | `"all"` string at offset `0xF8`; fallback magic at offset 2 (`0x0013`=v16.x, `0x0014`=v17.x, `0x0015`=v18+) for files where Cadence `dbdoctor` overwrote the header. |
+| Version coverage | Shipped C++ reads **v16 → v23** (seven major releases incl. the OrCAD X / 23.x rebrand). Dev-docs page conservatively says 16.0–17.5. **v17.2** introduced the biggest binary-layout change (many struct fields conditionally present around that boundary). |
+| Availability | KiCad 10 (≈Feb–Apr 2026). `pcbnew` Python module + `kicad-cli` ship on Windows/macOS/Linux. |
+
+### How to invoke headlessly (critical detail)
+
+`kicad-cli pcb import` **does NOT support Allegro** in 10.0 — its `--format` list is
+`pads, altium, eagle, cadstar, fabmaster, pcad, solidworks`. The GUI importer exists but was
+not wired into the CLI for the 10.0 release.
+
+The working headless path is the bundled **Python `pcbnew` API** (KiCad 10+ only; the
+`ALLEGRO` enum is absent in 9.0):
+
+```python
+import pcbnew
+board = pcbnew.PCB_IO_MGR.Load(pcbnew.PCB_IO_MGR.ALLEGRO, "design.brd")
+pcbnew.PCB_IO_MGR.Save(pcbnew.PCB_IO_MGR.KICAD_SEXP, "design.kicad_pcb", board)
+```
+
+So the pipeline is: drive `pcbnew` as an external interpreter → emit `.kicad_pcb` (open
+S-expression) → parse that in pcb-lens. This keeps GPL out of our codebase and gives us a
+text format that is trivial to parse.
+
+## What it extracts (vs. what still needs Cadence)
+
+| Data pcb-lens needs | KiCad `pcbnew` (no Cadence) | Notes |
+|---|---|---|
+| Nets / connectivity | ✅ | NET blocks (`0x1B`) |
+| Tracks / arcs (width + net) | ✅ | derived copper geometry |
+| Vias | ✅ | padstack-defined drill (version-dependent: pre-V172 `m_Drill` vs V172+ `m_DrillArr`) |
+| Padstacks / pad shapes / thermal relief | ✅ | circle, square, rect, oblong, rounded/chamfered rect, octagon, custom poly; `thermal_gap = (antipad.W − pad.W)/2` |
+| Components / placement | ✅ | refdes, value, position, rotation (millidegrees), top/bottom layer |
+| Board outline | ✅ | → `Edge.Cuts` |
+| Copper zones | ✅ | from BOUNDARY-class shapes |
+| Constraints (clearance, trace width, diff-pair gap) | ✅ | Physical Constraint Sets (`0x1D`) → KiCad **netclasses**; per-net width overrides; 2-net groups → diff-pair netclasses |
+| **Layer stackup** (material / Dk / thickness / Cu weight) | ❌ | **not extracted** — "stackup" in KiCad docs means copper-layer *ordering* only |
+| Per-pad solder/paste mask expansion | ❌ | not extracted |
+| Schematic / footprint library | ❌ | board-only (`.brd`); several exotic pad shapes + ANTI_ETCH/SI models also skipped |
+
+Caveat on constraints: constraint-set *names* can be synthetic on boards with unresolvable
+string-table keys; the data lands as KiCad netclasses, not a standalone Allegro constraints
+report.
+
+## Dead ends (ruled out for a no-Cadence pipeline)
+
+- **Cadence free viewers** (Allegro X Free Viewer / Free Physical Viewer): open `.brd` but are
+  **Windows-only, read-only, zero export** (no IPC-2581/ODB++/Gerber/netlist). Useless for
+  automation.
+- **extracta / IPC-2581 / GENCAD export:** all require a **paid PCB Editor license** — exactly
+  the dependency we are trying to remove. (`system76/kicad-allegro` is *not* a binary parser:
+  it reads `!`-delimited CSVs that extracta already produced, so it still needs Cadence — but
+  note those CSVs *do* carry full stackup/netlist/placement.)
+- **OpenAllegroParser:** never implemented a `.brd` parser (only `.pad`); stalled 2022, now
+  archived.
+- **IPC-2581 free viewers** (WISE, Vu2581, ZofzPCB, PCB Preflight): consume IPC-2581 only;
+  cannot read `.brd`.
+
+## Licensing constraint (decisive)
+
+pcb-lens is **Apache-2.0** and published to npm. KiCad is **GPLv3-or-later**. Copying or
+porting KiCad's `.brd` logic into pcb-lens — or linking `pcbnew` in-process — makes pcb-lens a
+GPL derivative. That is not acceptable for this project. What *is* clean:
+
+- Invoke `pcbnew`/KiCad as a **separate external process** and consume the `.kicad_pcb` file
+  (process boundary = aggregation, no copyleft propagation). This mirrors the existing
+  Cadence shell-out model — we'd swap "Cadence on Windows" for "KiCad on any OS."
+- Reimplementing a `.brd` parser from the reverse-engineered *format facts* (offsets, block
+  types) is legally cleaner but a large effort and version-fragile; not recommended near-term.
+
+Deployment cost: this requires a **KiCad 10 install present on the host** (for `pcbnew`),
+which is heavier than bundling a small CLI. Treat KiCad as an external prerequisite rather
+than vendoring it.
+
+## Recommendation
+
+1. **Adopt a hybrid pipeline.** Use KiCad 10 `pcbnew` (external process) for layout,
+   connectivity, padstacks, and constraints cross-platform; keep the IPC-2581/Cadence path
+   **only for stackup** until/unless stackup can be recovered another way.
+2. **Smoke-test before committing.** The API surface is verified from docs, but no real
+   conversion was run. Run `PCB_IO_MGR.Load(..., ALLEGRO, ...)` against real fixtures —
+   ideally one pre-v17.2, one v17.2+, and one v22/v23 OrCAD X board — since the parser "may
+   not cover every variation."
+3. **Parse `.kicad_pcb`, not KiCad internals.** Add a `.kicad_pcb` S-expression reader to
+   pcb-lens; do not link `pcbnew`.
+
+## Open questions / next actions
+
+- Does the imported `.kicad_pcb` retain **any** usable stackup (even copper-weight/thickness),
+  or strictly copper-layer mapping? This gates whether stackup can ever leave the Cadence path.
+- Is there an actively-maintained **standalone** (non-KiCad) Python/Rust/JS `.brd` library that
+  wraps or reimplements KiCad's reverse-engineered logic, so we could avoid bundling the full
+  KiCad toolchain?
+- How robust is the importer on real **v22/v23 OrCAD X** boards in practice (fixture testing
+  against our own designs)?
+- Operationally: ship KiCad as a host prerequisite vs. container the converter as a sidecar?
+
+## Sources
+
+Primary-heavy: KiCad official dev-docs, blog, and source; the actual GitHub repos; Cadence's
+own Free Viewer FAQ.
+
+- KiCad Allegro import dev-docs: <https://dev-docs.kicad.org/en/import-formats/allegro/index.html>
+- KiCad 10 importers announcement: <https://www.kicad.org/blog/2026/02/Three-New-Importers-in-KiCad-10-Allegro-PADS-and-gEDA/>
+- `pcb_io_allegro.cpp` source: <https://docs.kicad.org/doxygen/pcb__io__allegro_8cpp_source.html>
+- `kicad-cli` 10.0 reference (PCB import `--format` list): <https://docs.kicad.org/10.0/en/cli/cli.html>
+- `PCB_IO_MGR` Python API (10.0, shows `ALLEGRO` enum): <https://docs.kicad.org/doxygen-python-10.0/classpcbnew_1_1PCB__IO__MGR.html>
+- KiCad licenses (GPLv3+): <https://www.kicad.org/about/licenses/>
+- system76/kicad-allegro (extracta-CSV, not binary): <https://github.com/system76/kicad-allegro>
+- OpenAllegroParser (archived, .pad only): <https://github.com/Werni2A/OpenAllegroParser>
+- Cadence Allegro X Free Viewer FAQ (read-only, no export): <https://resources.pcb.cadence.com/blog/allegro-x-free-viewer-faq>
+- IPC-2581 free viewers: <https://www.ipc2581.com/free-viewer/>
+
+> Research method: deep-research workflow — 97 agents, 15 sources fetched, 57 claims
+> extracted, 25 adversarially verified (22 confirmed, 3 killed), plus a follow-up agent that
+> verified the `kicad-cli` vs `pcbnew` headless-invocation path and the stackup gap directly
+> against the KiCad 10 docs.

--- a/plans/altium-pcbdoc-parser-research.md
+++ b/plans/altium-pcbdoc-parser-research.md
@@ -1,0 +1,105 @@
+# Reading Altium PcbDoc Files — Open-Source Parser Research
+
+**Status:** Research / not yet scheduled
+**Date:** 2026-06-17
+**Goal:** Extract everything from Altium PCB layout files (copper/routing, layer stackup,
+design rules/constraints, nets, components/footprints, vias, polygons) programmatically,
+analogous to how pcb-lens parses IPC-2581 XML today.
+
+## Bottom line
+
+**No existing JavaScript/TypeScript library reads Altium PcbDoc PCB data.** Unlike IPC-2581
+(an open XML schema parsed directly), a PcbDoc reader is a two-layer build:
+
+1. **Outer layer (solved in JS).** Every Altium binary file (`.PcbDoc`, `.PcbLib`, `.SchDoc`,
+   `.SchLib`) is a Microsoft OLE / Compound File Binary (CFB) container — magic
+   `D0 CF 11 E0 A1 B1 1A E1`, FAT/MiniFAT sector tables, and a directory tree of named
+   storages/streams. A JS CFB library handles this.
+2. **Inner layer (must be ported/reverse-engineered).** Inside are named storages —
+   `Board6`, `Nets6`, `Components6`, `Rules6`, `Polygons6`, `Vias6`, `Tracks6`, `Arcs6`,
+   `Pads6`, etc. — each usually a `Header` stream (record count) plus a `Data` stream. The
+   per-record binary/text layouts are reverse-engineered (undocumented by Altium) and must be
+   ported from an existing parser.
+
+## Reference parsers (ranked by usefulness to pcb-lens)
+
+| Tool | Lang | License | PcbDoc coverage | Notes |
+|---|---|---|---|---|
+| **KiCad `altium_pcb.cpp`** | C++ | **GPLv3** | Board/stackup, Components, Nets, Rules, Polygons, Vias, Tracks, Pads, Arcs, Fills, Regions, Classes | Most complete + actively maintained. **GPLv3 — cannot be copied or ported into Apache-2.0 pcb-lens.** Usable only as a black-box behavioral reference. |
+| **AltiumSharp** (`OriginalCircuit.Altium`) | C#/.NET | **unverified — must confirm** | Read+write all 4 doc types; layout primitives, per-net copper, board outline, layer stack, design rules | Cleanest library-shaped port source **if** its license is permissive. |
+| **AtoK** (stevegrn) | C#/.NET | GPLv3 | PcbDoc-only via OpenMCDF; Nets/Tracks/Vias/Pads/Polygons/Rules/Dimensions/DiffPairs/Classes/Models | GPLv3 — reference only, not portable. |
+| **altium2kicad** (thesourcerer8) | Perl | n/a | unpack→convert PcbDoc+SchDoc; `unpack.pl` is a clean CDF decomposer | Old/low-activity. Rule-extraction extent uncertain (verification vote split). |
+| **pluots/altium** | Rust | Apache-2.0 | **Cannot read PcbDoc/PcbLib today** (alpha; SchDoc/SchLib partial) | Not usable now; 0.2.0 rewrite in progress as of Feb 2026. |
+| **vadmium/python-altium** | Python | n/a | **SchDoc only** — canonical schematic spec, zero PCB | Inner-record encoding reference for schematic files only. |
+
+**PrjPcb project files are essentially unsupported across all surveyed tools.**
+
+## Licensing constraint (decisive)
+
+pcb-lens is **Apache-2.0** and published to npm, so **GPLv3 sources cannot be copied or
+ported** — translating C++→TS is a derivative work and the copyleft travels with the logic,
+not the syntax. This rules out reusing KiCad's `altium_pcb.cpp` or AtoK as code.
+
+What is legal:
+- Use KiCad/AtoK as a **black-box behavioral reference** — rule names (`CLEARANCE`, `WIDTH`,
+  `HOLE_TO_HOLE_CLEARANCE`, ...), stream dispatch order
+  (`BOARD6 → COMPONENTS6 → NETS6 → RULES6 → POLYGONS6 → VIAS6 → TRACKS6`), units. The file
+  format structure and these facts are not copyrightable.
+- Run KiCad as an external CLI tool (no source incorporation) — heavy, undesirable for an MCP server.
+
+The clean route is therefore: **port from AltiumSharp if its license is permissive**;
+otherwise reverse-engineer the record formats from the format facts directly.
+
+## Recommended implementation path
+
+1. **Outer container:** use **`js-cfb`** (SheetJS). Verified API: `CFB.read(...)`,
+   `CFB.find(cfb, path)` → entry whose `.content` is the raw stream `Buffer`;
+   `FullPaths`/`FileIndex` enumerate the directory. That is the mechanism to pull each named
+   record stream out of a PcbDoc. Alternative: generate a CFB parser from the **Kaitai Struct**
+   `.ksy` (it has a JS target) — but do **not** assume a maintained npm Kaitai CFB package
+   exists (that claim was refuted); generate it yourself or just use `js-cfb`.
+2. **Inner records:** port stream-by-stream. Each `Data` stream is a sequence of records
+   (typically a `uint8` type tag + length-prefixed subrecords). Prioritize what mirrors the
+   IPC-2581 tools: `Board6` (stackup/layers), `Nets6`, `Components6`, `Rules6` (constraints),
+   then routing primitives `Tracks6`/`Arcs6`/`Vias6`/`Pads6`/`Polygons6`/`Regions6`.
+3. **Resolve the license fork first** (see Open questions) — it determines whether step 2 is a
+   port or a from-scratch reverse-engineering effort.
+
+## Caveats
+
+- **Not lossless.** Even KiCad maps Altium rules into its own model (e.g. `HOLE_SIZE`
+  placeholdered) rather than preserving verbatim. Full-fidelity constraint extraction
+  comparable to the IPC-2581 path will need a more complete `Rules6` parse than any converter does.
+- **Format drift.** Inner record layouts are reverse-engineered and can change across Altium
+  Designer versions; none of these parsers guarantee version-stable extraction. Plan for
+  version-tolerant parsing and multi-version test fixtures.
+- **Verification gaps.** The research run hit API rate-limiting during the verify phase, so
+  several JS/npm-packaging convenience claims (`cfb`/`js-cfb` npm specifics, Kaitai npm
+  readiness) were abstained/refuted rather than confirmed. The core facts below
+  (js-cfb type API, CFB-as-container, the C#/C++ parser coverage) are solid (3-0 / 2-0); treat
+  npm-packaging specifics as "verify at install time."
+
+## Open questions / next actions
+
+- **Confirm AltiumSharp / `OriginalCircuit.Altium` license.** This is the gating decision: a
+  permissive license makes it the port source; otherwise reverse-engineer from format facts.
+- How stable are Altium's inner binary record formats across Altium Designer versions, and which
+  versions are the surveyed parsers validated against?
+- Does any tool extract the complete design-rule/constraint set **verbatim** (not mapped into
+  another EDA tool's model) so it can be exported analogously to pcb-lens's IPC-2581 constraints?
+- Prototype: open a real `.PcbDoc` with `js-cfb` and dump its storage/stream tree to confirm the
+  actual `*6` streams before committing to a port source.
+
+## Sources
+
+- KiCad importer: <https://docs.kicad.org/doxygen/altium__pcb_8cpp_source.html>
+  (source: `gitlab.com/kicad/code/kicad`, `pcbnew/pcb_io/altium/`)
+- AltiumSharp: <https://github.com/issus/AltiumSharp>
+- AtoK: <https://github.com/stevegrn/AtoK>
+- altium2kicad: <https://github.com/thesourcerer8/altium2kicad>
+- python-altium SchDoc spec: <https://github.com/vadmium/python-altium/blob/master/format.md>
+- pluots/altium (Rust): <https://github.com/pluots/altium>
+- js-cfb: <https://github.com/SheetJS/js-cfb>
+- Kaitai CFB (JS): <https://formats.kaitai.io/microsoft_cfb/javascript.html>
+- pyaltiumlib file structure: <https://pyaltiumlib.readthedocs.io/latest/fileformat/FileStructure.html>
+- CFB format (Wikipedia): <https://en.wikipedia.org/wiki/Compound_File_Binary_Format>

--- a/plans/ipc2581-layout-review.md
+++ b/plans/ipc2581-layout-review.md
@@ -1,0 +1,68 @@
+# IPC-2581 Layout Review — Research & Prototype Plan
+
+## Context
+
+We want to enable LLM-driven PCB layout review for Cadence Allegro designs. The netlist MCP server already handles schematic connectivity; this would add the physical layout dimension — component placement, footprints, traces, planes, spacing, etc.
+
+Rather than building tools upfront, we first need to validate whether IPC-2581 XML is navigable enough with basic tools (Read, Grep, Bash) that an LLM can reason about layout data directly, and identify where thin extraction tooling is actually needed.
+
+## Why IPC-2581
+
+- Cadence Allegro `.brd` files are proprietary binary — not parseable without reverse-engineering
+- IPC-2581 is an industry-standard XML export that Allegro supports natively (File → Export → IPC2581)
+- Single XML file containing all layout data: placement, routing, stackup, footprints, vias, copper pours
+- RevC (latest) is the most comprehensive — supports rigid-flex, embedded components, 3D thermal data
+- Export is a one-time manual step (or automatable via Allegro CLI, like we do with `export_cadence_netlist`)
+
+## Prototype Steps
+
+### 1. Get a sample IPC-2581 RevC XML
+
+- Export from Cadence Allegro: File → Export → IPC2581, select RevC, millimeters
+- Place in test fixtures of the new codebase
+- Optionally download IPC-2581 Consortium test case (BeagleBone Black) as second data point:
+  `https://www.ipc2581.com/b-test-cases/` or RevC cases from `https://www.ipc2581.com/ipc-2581-revc-test-cases/`
+
+### 2. Assess file size and structure
+
+- Check raw XML file size — determines if Read tool can handle sections
+- Read first ~200 lines to map top-level elements (Content, Ecad, Bom, etc.)
+- Count lines per major section with grep to understand data distribution
+- Note how cross-references work (packageRef, layerRef, padstackRef)
+
+### 3. Test real layout review queries with raw tools
+
+| # | Query | Tests |
+|---|-------|-------|
+| 1 | "Where is U1 placed?" | Grep refdes → read coordinates, rotation, layer |
+| 2 | "What's the layer stackup?" | Find Stackup section → read layer order, materials, thicknesses |
+| 3 | "What traces are on net DDR_D0?" | Follow net routing across LayerFeature sections |
+| 4 | "What's the footprint of C1?" | Resolve packageRef → read pad geometry |
+| 5 | "List all components on bottom layer" | Filter by layer/side/mountType attributes |
+| 6 | "What via types are used?" | Find padstack definitions for vias |
+| 7 | "Trace widths on a high-speed net" | Extract LineDesc width attributes for a specific net |
+
+For each query, document:
+- Did it work with raw tools? How many steps?
+- What cross-references needed chasing?
+- Was the output LLM-digestible or too verbose?
+
+### 4. Decide on tooling
+
+Based on results, determine:
+- Which queries work raw → no tool needed
+- Which queries need a thin extraction tool → define inputs/outputs
+- Whether file size requires chunked access tooling
+- Minimum viable tool set for useful layout review
+
+## Separate Codebase
+
+This will be a new project, separate from the netlist MCP server. The netlist server handles schematic connectivity; this handles physical layout. They can cross-reference each other (same refdes/net names) but are architecturally independent.
+
+## References
+
+- [IPC-2581 Consortium](http://www.ipc2581.com/) — test cases, spec info
+- [OpenAllegroParser](https://github.com/Werni2A/OpenAllegroParser) — FOSS .brd parser (future option for direct binary parsing)
+- [boardui](https://github.com/midub/boardui) — IPC-2581 web viewer with parser package
+- [Cadence IPC-2581 Export Guide](https://community.cadence.com/cadence_blogs_8/b/pcb/posts/ipc-2581-pcb)
+- [Sierra Circuits: How to Export IPC-2581](https://www.protoexpress.com/kb/how-to-export-and-get-started-with-ipc-2581/)

--- a/plans/odbpp-parser-research.md
+++ b/plans/odbpp-parser-research.md
@@ -1,0 +1,132 @@
+# ODB++ Open-Source Parser Research
+
+> Status: research / decision input · Date: 2026-06-17
+> Question: which open-source ODB++ parsers can we build on to read everything from a
+> Cadence Allegro / OrCAD ODB++ export (layout geometry, stackup, netlist/connectivity,
+> design constraints/rules), to reach the same programmatic-querying parity we already
+> have for IPC-2581 in this TypeScript MCP server?
+
+## Bottom line
+
+For a TypeScript MCP server the deciding factor is **licensing, not capability**. There is
+no production-grade, permissively-licensed, JS-native ODB++ parser. The two realistic paths:
+
+1. **Write a focused native TS parser** against the free official spec, reusing the same
+   per-subsystem architecture we already use for IPC-2581.
+2. **Run the C++ `OdbDesign` as a REST/gRPC sidecar** — only if AGPL service-boundary use
+   survives legal review.
+
+Do **not** link the C++ core in-process into a proprietary server.
+
+Good news on data: **ODB++ carries everything asked about** — stackup, full netlist,
+geometry, and (contrary to common belief) real constraints/rules — though constraint
+completeness depends on the Allegro exporter/version.
+
+## The parsers
+
+| Parser | Lang | License | Maturity | Coverage | TS path? |
+|---|---|---|---|---|---|
+| **OdbDesign** (`nam20485`) | C++ | **AGPL-3.0** | Most complete, active (last push 2026-06), ~80★ | Full: archives, netlist, product models; REST + gRPC in Docker | Only via REST/gRPC sidecar or C++ linking — **never in-process JS** |
+| **ODBPy** (`ulikoehler`) | Python | **Apache-2.0** (best license) | **Alpha, unmaintained since 2019** | netlist, components, layers (matrix/stackup inside `Layers.py`), features, attributes, drill, profile, polygon/surface geometry | No native path — useful as a **structural reference** for a TS port |
+| **PyOdbDesignLib** | Python | MIT wrapper / **AGPL core** | v0.0.1 (2023, no updates) | Thin wrapper over the C++ core | No — wrapper's MIT label does not launder the AGPL core |
+| KiCad `odb_eda_data.cpp` | C++ | GPL | Production (KiCad importer) | NET/SNT/PKG/PIN netlist | Credible **reference implementation** to port from |
+
+**Killed claims** (failed adversarial verification): OdbDesign does *not* actually achieve
+"complete coverage" of the file hierarchy (its own claim, refuted 0-3); the Ruby
+`odb-pp-parser` description was unreliable (1-2).
+
+## What ODB++ actually contains (verified against the official spec)
+
+- **Stackup / layer order** — single `matrix` file per product model: rows = layers
+  (type/polarity/context), columns = steps; defines physical order and through/blind/buried
+  drill relationships. Dielectric/material lives in a separate `stackups` file. An optional
+  `stackup.xml` is being introduced to eventually replace the matrix file.
+- **Netlist / connectivity** — `eda/data` file: `NET`, `SNT` (subnet), `PKG` (package),
+  `PIN` records; components are `CMP` records referencing packages. KiCad's importer
+  independently implements these same keywords.
+- **Geometry / features** — copper, pads, traces, vias via feature/layer records.
+- **Constraints / rules — yes, they exist**, two ways:
+  - **System attributes** (Appendix B): `.diff_pair`, `.dpair_gap`, `.electrical_class`,
+    `.eclass_impedance`, `.imp_constraint_id` (→ impedance constraints table),
+    `.min_line_width`. (`.drc_min_space`/`.drc_min_width` are flagged *obsolete* — the
+    SI/net attributes are the live ones.)
+  - **`net_prp` file**: Net Type Clearance Records (width/clearance rules), Electrical
+    Parameter Set (`dpair_prim_gap`, `dpair_line_width`, `dpair_neck_gap`, phase
+    tolerances), explicitly **"read from Cadence Allegro."**
+- **Extras**: rigid-flex buildup zones, soldermask finish color, test-probe position/size,
+  intentional-short nets.
+
+## ⚠️ The Cadence caveat (biggest open risk)
+
+The `net_prp` electrical/physical constraint records are **version-gated** (clearances
+V5.3+, physical params V7.1+) and populated *by the Allegro exporter*. Whether a real
+Allegro/OrCAD ODB++ export actually carries the constraints — or whether they stay locked
+in proprietary `.brd`/Constraint Manager files — is **not guaranteed and must be
+empirically checked on a real export** before building on it. This is the #1 thing to
+validate first.
+
+This mirrors what we already see with `export_cadence_constraints` needing a separate
+`.tcfx` file in pcb-lens — design intent often lives outside the manufacturing-oriented
+export.
+
+## Spec documentation
+
+Officially free: the **ODB++ Design Format Specification** downloads from odbplusplus.com /
+Siemens after a no-cost signup, no access restrictions. **Current = v8.1 Update 4
+(Aug 2024, 515 pp)** — the site's embedded viewer still shows the older Update 3 (2021), so
+grab Update 4 from its direct URL. Caveat: free to *access*, but *use/redistribution* is
+contractually restricted under the Siemens Universal Customer Agreement (trade-secret
+notice) — relevant if we reproduce spec text or ship a derived parser.
+
+## ODB++ vs IPC-2581 for this use case
+
+- **Coverage**: roughly comparable for layout/stackup/netlist; IPC-2581 is generally
+  regarded as **stronger at explicit design-intent/constraint capture**, ODB++
+  comparatively weaker (constraints are attribute/exporter-dependent rather than a
+  first-class rules database).
+- **Governance**: ODB++ is **single-vendor (Siemens)**, de facto proprietary; IPC-2581 is a
+  neutral consortium standard (Cadence/Zuken/Ucamco), created partly out of frustration with
+  ODB++'s proprietary nature. Lock-in consideration: we already have the more open path
+  working.
+
+## Recommendation
+
+1. **First, validate the data, not the parser.** Get one real Cadence/OrCAD ODB++ export and
+   inspect whether `net_prp` + constraint attributes are actually populated. If constraints
+   don't survive the export, ODB++ buys layout/stackup/netlist but *not* the constraint
+   parity we have via `.tcfx` — that changes the whole value proposition.
+2. **Build a focused native TS parser against the v8.1 Update 4 spec**, targeting only
+   `matrix`, `eda/data`, `features`, `attributes`, `net_prp`. ODB++ is largely a directory
+   tree of line-oriented ASCII records — well-suited to the same per-subsystem parser
+   approach used for IPC-2581. Use **ODBPy and KiCad's `odb_eda_data.cpp` as reference
+   implementations**, not dependencies.
+3. **Avoid `OdbDesign` in-process** (AGPL-3.0; its README explicitly says unsuitable for
+   closed-source). A REST/gRPC sidecar *might* be acceptable but **get legal sign-off on
+   AGPL service-boundary obligations** first. The maintainer offers a commercial license.
+
+### Open questions
+
+- Do real Allegro/OrCAD exports actually populate the constraint fields? (gating question)
+- Is sidecar mode enough to avoid AGPL copyleft for a proprietary server, and is the
+  commercial license practical to obtain?
+- Effort estimate: native TS parser vs. integrating the C++ core, given we only need ~5
+  subsystems.
+
+## Sources
+
+Primary-heavy. Official Siemens/odbplusplus spec PDFs (v7.0, v8.1, Update 4), the OdbDesign
+and ODBPy repos, PyPI, KiCad source, plus IPC-2581-vs-ODB++ comparison pieces.
+
+- ODB++ Design Format Specification (v8.1 Update 4): https://odbplusplus.com/design/odb-design-format-specification/
+- Siemens ODB++ resources: https://www.siemens.com/en-us/products/pcb/odb-plus-plus/resources/
+- ODB++ spec PDF (8.1): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/odb_spec_user.pdf
+- ODB++ Format Description (v7.0): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/ODB_Format_Description_v7.pdf
+- Introduction to ODB++ (8.1): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/Introduction-to-ODB-version-8-1.pdf
+- OdbDesign (C++, AGPL-3.0): https://github.com/nam20485/OdbDesign
+- ODBPy (Python, Apache-2.0): https://github.com/ulikoehler/ODBPy
+- PyOdbDesignLib: https://pypi.org/project/PyOdbDesignLib/
+- ODB++ GitHub topic: https://github.com/topics/odbplusplus
+- Cadence brd2odb help: https://odbplusplus.com/wp-content/uploads/sites/2/2023/06/brd2odb_help.pdf
+
+> Research method: deep-research workflow — 101 agents, 19 sources fetched, 88 claims
+> extracted, 25 adversarially verified (23 confirmed, 2 killed).


### PR DESCRIPTION
## Summary

Adds a git-tracked `plans/` folder with research / decision-input docs on reading proprietary PCB layout files **without their native vendor toolchains**, plus the pre-existing IPC-2581 prototype plan. Also removes `.plans/` from `.gitignore` so the folder is versioned (matching the `universal-netlist` convention).

This is the integration PR collecting the parallel research efforts into one place.

## Plans added

| Plan | Topic |
|---|---|
| `allegro-brd-direct-read.md` | Cadence Allegro `.brd` via **KiCad 10's `pcbnew` importer** (cross-platform, no Cadence). Covers version coverage (v16–v23), the headless `pcbnew` API path (`kicad-cli` does **not** support Allegro), the **stackup-extraction gap**, and the GPLv3 → separate-process licensing constraint. |
| `altium-pcbdoc-parser-research.md` | Altium `.PcbDoc`: OLE/CFB container (`js-cfb`) wrapping reverse-engineered `*6` record streams; port source gated on AltiumSharp's license. |
| `odbpp-parser-research.md` | ODB++ parser survey; strong data coverage but **licensing** (AGPL `OdbDesign`) is the gate; recommends a native TS parser against the free v8.1 spec. |
| `ipc2581-layout-review.md` | The original IPC-2581 layout-review prototype plan (previously untracked under `.plans/`). |

`plans/README.md` indexes all four.

## Cross-cutting takeaway

For all three parser-research docs, the blocker is rarely data coverage — it's **licensing** (GPL/AGPL copyleft vs. pcb-lens's Apache-2.0) and the **Cadence-export dependency** for design intent (constraints, stackup). Each doc flags a "validate on a real export first" step before any build.

## Notes

- Docs only — no source or runtime changes.
- `.gitignore`: drops the `.plans/` ignore line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)