### PR TITLE
docs: address PR #34 review feedback on research plans

### DIFF
--- a/plans/altium-pcbdoc-parser-research.md
+++ b/plans/altium-pcbdoc-parser-research.md
@@ -26,7 +26,7 @@ analogous to how pcb-lens parses IPC-2581 XML today.
 | Tool | Lang | License | PcbDoc coverage | Notes |
 |---|---|---|---|---|
 | **KiCad `altium_pcb.cpp`** | C++ | **GPLv3** | Board/stackup, Components, Nets, Rules, Polygons, Vias, Tracks, Pads, Arcs, Fills, Regions, Classes | Most complete + actively maintained. **GPLv3 — cannot be copied or ported into Apache-2.0 pcb-lens.** Usable only as a black-box behavioral reference. |
-| **AltiumSharp** (`issus/AltiumSharp`) | C#/.NET | **Apache-2.0** ✓ (verified) | Read+write all 4 doc types; layout primitives, per-net copper, board outline, layer stack, design rules | Cleanest library-shaped port source; Apache-2.0 is compatible with pcb-lens → **recommended port source.** |
+| **AltiumSharp** (`issus/AltiumSharp`) | C#/.NET | **Apache-2.0** ✓ ([LICENSE](https://github.com/issus/AltiumSharp/blob/master/LICENSE)) | Read+write all 4 doc types; layout primitives, per-net copper, board outline, layer stack, design rules | Cleanest library-shaped port source; Apache-2.0 is compatible with pcb-lens → **recommended port source.** |
 | **AtoK** (stevegrn) | C#/.NET | GPLv3 | PcbDoc-only via OpenMCDF; Nets/Tracks/Vias/Pads/Polygons/Rules/Dimensions/DiffPairs/Classes/Models | GPLv3 — reference only, not portable. |
 | **altium2kicad** (thesourcerer8) | Perl | n/a | unpack→convert PcbDoc+SchDoc; `unpack.pl` is a clean CDF decomposer | Old/low-activity. Rule-extraction extent uncertain (verification vote split). |
 | **pluots/altium** | Rust | Apache-2.0 | **Cannot read PcbDoc/PcbLib today** (alpha; SchDoc/SchLib partial) | Not usable now; 0.2.0 rewrite in progress as of Feb 2026. |
@@ -48,8 +48,11 @@ What is legal:
 - Run KiCad as an external CLI tool (no source incorporation) — heavy, undesirable for an MCP server.
 
 The clean route is therefore: **port from AltiumSharp** — verified **Apache-2.0**
-(`issus/AltiumSharp`), compatible with pcb-lens's Apache-2.0. Reverse-engineering the record
-formats from format facts remains the fallback if a port proves impractical.
+([`issus/AltiumSharp`](https://github.com/issus/AltiumSharp/blob/master/LICENSE)), compatible
+with pcb-lens's Apache-2.0. (The separate `OriginalCircuit.Altium.*` helper repos are MIT —
+also permissive — but are independent of the core library, not transitive dependencies of a
+port.) Reverse-engineering the record formats from format facts remains the fallback if a port
+proves impractical.
 
 ## Recommended implementation path
 

--- a/plans/altium-pcbdoc-parser-research.md
+++ b/plans/altium-pcbdoc-parser-research.md
@@ -26,7 +26,7 @@ analogous to how pcb-lens parses IPC-2581 XML today.
 | Tool | Lang | License | PcbDoc coverage | Notes |
 |---|---|---|---|---|
 | **KiCad `altium_pcb.cpp`** | C++ | **GPLv3** | Board/stackup, Components, Nets, Rules, Polygons, Vias, Tracks, Pads, Arcs, Fills, Regions, Classes | Most complete + actively maintained. **GPLv3 — cannot be copied or ported into Apache-2.0 pcb-lens.** Usable only as a black-box behavioral reference. |
-| **AltiumSharp** (`OriginalCircuit.Altium`) | C#/.NET | **unverified — must confirm** | Read+write all 4 doc types; layout primitives, per-net copper, board outline, layer stack, design rules | Cleanest library-shaped port source **if** its license is permissive. |
+| **AltiumSharp** (`issus/AltiumSharp`) | C#/.NET | **Apache-2.0** ✓ (verified) | Read+write all 4 doc types; layout primitives, per-net copper, board outline, layer stack, design rules | Cleanest library-shaped port source; Apache-2.0 is compatible with pcb-lens → **recommended port source.** |
 | **AtoK** (stevegrn) | C#/.NET | GPLv3 | PcbDoc-only via OpenMCDF; Nets/Tracks/Vias/Pads/Polygons/Rules/Dimensions/DiffPairs/Classes/Models | GPLv3 — reference only, not portable. |
 | **altium2kicad** (thesourcerer8) | Perl | n/a | unpack→convert PcbDoc+SchDoc; `unpack.pl` is a clean CDF decomposer | Old/low-activity. Rule-extraction extent uncertain (verification vote split). |
 | **pluots/altium** | Rust | Apache-2.0 | **Cannot read PcbDoc/PcbLib today** (alpha; SchDoc/SchLib partial) | Not usable now; 0.2.0 rewrite in progress as of Feb 2026. |
@@ -47,8 +47,9 @@ What is legal:
   format structure and these facts are not copyrightable.
 - Run KiCad as an external CLI tool (no source incorporation) — heavy, undesirable for an MCP server.
 
-The clean route is therefore: **port from AltiumSharp if its license is permissive**;
-otherwise reverse-engineer the record formats from the format facts directly.
+The clean route is therefore: **port from AltiumSharp** — verified **Apache-2.0**
+(`issus/AltiumSharp`), compatible with pcb-lens's Apache-2.0. Reverse-engineering the record
+formats from format facts remains the fallback if a port proves impractical.
 
 ## Recommended implementation path
 
@@ -62,8 +63,9 @@ otherwise reverse-engineer the record formats from the format facts directly.
    (typically a `uint8` type tag + length-prefixed subrecords). Prioritize what mirrors the
    IPC-2581 tools: `Board6` (stackup/layers), `Nets6`, `Components6`, `Rules6` (constraints),
    then routing primitives `Tracks6`/`Arcs6`/`Vias6`/`Pads6`/`Polygons6`/`Regions6`.
-3. **Resolve the license fork first** (see Open questions) — it determines whether step 2 is a
-   port or a from-scratch reverse-engineering effort.
+3. **Port source is AltiumSharp** (Apache-2.0, verified) — step 2 is a port, not a from-scratch
+   reverse-engineering effort. Reverse-engineering from format facts remains the fallback only
+   if the C#→TS port proves impractical.
 
 ## Caveats
 
@@ -81,8 +83,9 @@ otherwise reverse-engineer the record formats from the format facts directly.
 
 ## Open questions / next actions
 
-- **Confirm AltiumSharp / `OriginalCircuit.Altium` license.** This is the gating decision: a
-  permissive license makes it the port source; otherwise reverse-engineer from format facts.
+- ~~Confirm AltiumSharp license.~~ **Resolved (2026-06-17):** `issus/AltiumSharp` is
+  **Apache-2.0** (the related `OriginalCircuit.Altium.*` helper repos are MIT) — compatible with
+  pcb-lens, so it is the port source rather than a reference-only fallback.
 - How stable are Altium's inner binary record formats across Altium Designer versions, and which
   versions are the surveyed parsers validated against?
 - Does any tool extract the complete design-rule/constraint set **verbatim** (not mapped into

--- a/plans/ipc2581-layout-review.md
+++ b/plans/ipc2581-layout-review.md
@@ -2,7 +2,7 @@
 
 **Status:** Reference — original prototype plan; validated and now realized by the current
 pcb-lens tools
-**Date:** early 2026 (original) · reviewed 2026-06-17
+**Date:** 2026-02 (original) · reviewed 2026-06-17
 **Goal:** Validate that IPC-2581 RevC XML is navigable enough for LLM-driven PCB layout review
 with thin extraction tooling, and decide where tooling is actually needed.
 

--- a/plans/ipc2581-layout-review.md
+++ b/plans/ipc2581-layout-review.md
@@ -1,5 +1,19 @@
 # IPC-2581 Layout Review — Research & Prototype Plan
 
+**Status:** Reference — original prototype plan; validated and now realized by the current
+pcb-lens tools
+**Date:** early 2026 (original) · reviewed 2026-06-17
+**Goal:** Validate that IPC-2581 RevC XML is navigable enough for LLM-driven PCB layout review
+with thin extraction tooling, and decide where tooling is actually needed.
+
+## Bottom line
+
+IPC-2581 RevC is navigable enough for LLM-driven layout review: a small set of thin
+extraction tools over the XML (metadata, component, net, constraints) is sufficient — which is
+what the current pcb-lens MCP tools implement. This document is kept as the original design
+input. For reading Cadence Allegro `.brd` *directly* (without the IPC-2581 export), see
+[allegro-brd-direct-read.md](allegro-brd-direct-read.md).
+
 ## Context
 
 We want to enable LLM-driven PCB layout review for Cadence Allegro designs. The netlist MCP server already handles schematic connectivity; this would add the physical layout dimension — component placement, footprints, traces, planes, spacing, etc.
@@ -62,7 +76,7 @@ This will be a new project, separate from the netlist MCP server. The netlist se
 ## References
 
 - [IPC-2581 Consortium](http://www.ipc2581.com/) — test cases, spec info
-- [OpenAllegroParser](https://github.com/Werni2A/OpenAllegroParser) — FOSS .brd parser (future option for direct binary parsing)
+- [OpenAllegroParser](https://github.com/Werni2A/OpenAllegroParser) — early FOSS Allegro parser. **Note:** never implemented a `.brd` parser (only `.pad`) and is archived (2022); not a viable path. For reading `.brd` directly, see [allegro-brd-direct-read.md](allegro-brd-direct-read.md) (KiCad 10's `pcbnew` importer).
 - [boardui](https://github.com/midub/boardui) — IPC-2581 web viewer with parser package
 - [Cadence IPC-2581 Export Guide](https://community.cadence.com/cadence_blogs_8/b/pcb/posts/ipc-2581-pcb)
 - [Sierra Circuits: How to Export IPC-2581](https://www.protoexpress.com/kb/how-to-export-and-get-started-with-ipc-2581/)

--- a/plans/odbpp-parser-research.md
+++ b/plans/odbpp-parser-research.md
@@ -117,16 +117,16 @@ notice) — relevant if we reproduce spec text or ship a derived parser.
 Primary-heavy. Official Siemens/odbplusplus spec PDFs (v7.0, v8.1, Update 4), the OdbDesign
 and ODBPy repos, PyPI, KiCad source, plus IPC-2581-vs-ODB++ comparison pieces.
 
-- ODB++ Design Format Specification (v8.1 Update 4): https://odbplusplus.com/design/odb-design-format-specification/
-- Siemens ODB++ resources: https://www.siemens.com/en-us/products/pcb/odb-plus-plus/resources/
-- ODB++ spec PDF (8.1): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/odb_spec_user.pdf
-- ODB++ Format Description (v7.0): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/ODB_Format_Description_v7.pdf
-- Introduction to ODB++ (8.1): https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/Introduction-to-ODB-version-8-1.pdf
-- OdbDesign (C++, AGPL-3.0): https://github.com/nam20485/OdbDesign
-- ODBPy (Python, Apache-2.0): https://github.com/ulikoehler/ODBPy
-- PyOdbDesignLib: https://pypi.org/project/PyOdbDesignLib/
-- ODB++ GitHub topic: https://github.com/topics/odbplusplus
-- Cadence brd2odb help: https://odbplusplus.com/wp-content/uploads/sites/2/2023/06/brd2odb_help.pdf
+- ODB++ Design Format Specification (v8.1 Update 4): <https://odbplusplus.com/design/odb-design-format-specification/>
+- Siemens ODB++ resources: <https://www.siemens.com/en-us/products/pcb/odb-plus-plus/resources/>
+- ODB++ spec PDF (8.1): <https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/odb_spec_user.pdf>
+- ODB++ Format Description (v7.0): <https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/ODB_Format_Description_v7.pdf>
+- Introduction to ODB++ (8.1): <https://odbplusplus.com/wp-content/uploads/sites/2/2020/03/Introduction-to-ODB-version-8-1.pdf>
+- OdbDesign (C++, AGPL-3.0): <https://github.com/nam20485/OdbDesign>
+- ODBPy (Python, Apache-2.0): <https://github.com/ulikoehler/ODBPy>
+- PyOdbDesignLib: <https://pypi.org/project/PyOdbDesignLib/>
+- ODB++ GitHub topic: <https://github.com/topics/odbplusplus>
+- Cadence brd2odb help: <https://odbplusplus.com/wp-content/uploads/sites/2/2023/06/brd2odb_help.pdf>
 
 > Research method: deep-research workflow — 101 agents, 19 sources fetched, 88 claims
 > extracted, 25 adversarially verified (23 confirmed, 2 killed).


### PR DESCRIPTION
Follow-up to #34, addressing the `claude-review` comments on that PR (which were not acted on before it merged).

## Changes

1. **OpenAllegroParser inconsistency (factual fix).** `ipc2581-layout-review.md` described OpenAllegroParser as a "FOSS .brd parser (future option)", contradicting `allegro-brd-direct-read.md` which correctly rules it out (never implemented `.brd`, archived 2022). Corrected and cross-linked.
2. **AltiumSharp license resolved.** The review noted this was checkable now. Verified: `issus/AltiumSharp` is **Apache-2.0** (related `OriginalCircuit.Altium.*` helper repos are MIT). Updated `altium-pcbdoc-parser-research.md` — it's now the *recommended port source*, not a license-gated maybe, which is a real upgrade to the recommendation.
3. **ipc2581 metadata convention.** Added the Status/Date/Goal + Bottom-line header the other three docs (and `plans/README.md` conventions) establish.
4. **URL formatting (minor).** Normalized the ODB++ doc's Sources to angle-bracket links to match the Allegro/Altium docs.

Docs only — no source/runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)