### PR TITLE
fix(get_pcb_component): correct pin count and pad geometry for chip passives (#38, #40)

### DIFF
--- a/src/tools/get-pcb-component.test.ts
+++ b/src/tools/get-pcb-component.test.ts
@@ -8,6 +8,10 @@ import { isErrorResult } from "./lib/types.js";
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../../test/fixtures");
 const BEAGLEBONE_REVB6 = path.join(FIXTURE_DIR, "BeagleBone_Black_RevB6.xml");
 const hasBeagleBoneFixture = existsSync(BEAGLEBONE_REVB6);
+const PARALLELLA_REVB = path.join(FIXTURE_DIR, "parallella-RevB.xml");
+const hasParallellaFixture = existsSync(PARALLELLA_REVB);
+const TESTCASE1_REVC = path.join(FIXTURE_DIR, "testcase1-RevC.xml");
+const hasTestcase1Fixture = existsSync(TESTCASE1_REVC);
 
 // ---------------------------------------------------------------------------
 // Inline fixtures
@@ -234,6 +238,113 @@ describe("queryComponent -- pad geometry", () => {
     }
   });
 
+  // Issue #40: chip-passive pads that reference their shape only through a
+  // padstack (no inline <StandardPrimitiveRef>) must still resolve, and oval
+  // primitives must be supported. Previously these returned empty pad geometry.
+  it("resolves pad shape via padstackDefRef when there is no inline primitive", async () => {
+    const xml = `<IPC-2581>
+  <Content>
+    <EntryStandard id="OVAL_1"><Oval width="0.3" height="0.4"/></EntryStandard>
+  </Content>
+  <CadHeader units="MILLIMETER"/>
+  <Ecad><CadData>
+    <PadStackDef name="CHIP_PAD">
+      <PadstackPadDef padUse="REGULAR"><StandardPrimitiveRef id="OVAL_1"/></PadstackPadDef>
+    </PadStackDef>
+    <Package name="RES0402">
+      <LandPattern>
+        <Pad padstackDefRef="CHIP_PAD"><Location x="-0.5" y="0"/><PinRef pin="1"/></Pad>
+        <Pad padstackDefRef="CHIP_PAD"><Location x="0.5" y="0"/><PinRef pin="2"/></Pad>
+      </LandPattern>
+    </Package>
+  </CadData></Ecad>
+  <Step>
+    <Component refDes="R1" packageRef="RES0402" layerRef="TOP"><Location x="10" y="20"/></Component>
+    <PhyNetGroup/>
+  </Step>
+</IPC-2581>`;
+    const f = path.join(tempDir, "passive-padstack.xml");
+    writeFileSync(f, xml);
+    const result = await queryComponent(f, "R1");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      // #40: pads are populated, not empty.
+      expect(result.padRows).toHaveLength(2);
+      expect(result.padShapes).toHaveLength(1);
+      expect(result.padShapes![0].shape).toBe("oval");
+      expect(result.padShapes![0].width).toBe(300);
+      expect(result.padShapes![0].height).toBe(400);
+      // #38: pin count is the real pad count (2), not the case-size code (402).
+      expect(result.parsed).toBeDefined();
+      expect(result.parsed!.packageFamily).toBe("RES");
+      expect(result.parsed!.pinCount).toBe(2);
+    }
+  });
+
+  // Issue #40: pad shapes defined as a <Contour><Polygon> (no width/height
+  // attribute) must be reported by their bounding box, not dropped.
+  it("resolves a polygon/contour pad shape by bounding box", async () => {
+    const xml = `<IPC-2581>
+  <Content>
+    <EntryStandard id="SHAPE_LS_POLY">
+      <Contour>
+        <Polygon>
+          <PolyBegin x="-0.2" y="-0.3"/>
+          <PolyStepSegment x="0.2" y="-0.3"/>
+          <PolyStepSegment x="0.2" y="0.3"/>
+          <PolyStepSegment x="-0.2" y="0.3"/>
+          <PolyStepSegment x="-0.2" y="-0.3"/>
+        </Polygon>
+      </Contour>
+    </EntryStandard>
+  </Content>
+  <CadHeader units="MILLIMETER"/>
+  <Ecad><CadData>
+    <Package name="SR0603">
+      <Pin number="1" type="SURFACE"><Location x="-0.5" y="0"/><StandardPrimitiveRef id="SHAPE_LS_POLY"/></Pin>
+      <Pin number="2" type="SURFACE"><Location x="0.5" y="0"/><StandardPrimitiveRef id="SHAPE_LS_POLY"/></Pin>
+    </Package>
+  </CadData></Ecad>
+  <Step>
+    <Component refDes="R7" packageRef="SR0603" layerRef="TOP"><Location x="10" y="20"/></Component>
+    <PhyNetGroup/>
+  </Step>
+</IPC-2581>`;
+    const f = path.join(tempDir, "passive-contour.xml");
+    writeFileSync(f, xml);
+    const result = await queryComponent(f, "R7");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.padRows).toHaveLength(2);
+      expect(result.padShapes).toHaveLength(1);
+      expect(result.padShapes![0].shape).toBe("polygon");
+      expect(result.padShapes![0].width).toBe(400); // 0.4mm bbox -> 400 micron
+      expect(result.padShapes![0].height).toBe(600); // 0.6mm bbox -> 600 micron
+    }
+  });
+
+  // Issue #38: without geometry, a chip-passive case size must NOT be emitted as
+  // a pin count; the family is still surfaced.
+  it("does not invent a pin count from a chip-passive case size", async () => {
+    const xml = `<IPC-2581>
+  <Content></Content>
+  <CadHeader units="MILLIMETER"/>
+  <Step>
+    <Component refDes="C9" packageRef="C0402" layerRef="TOP"><Location x="0" y="0"/></Component>
+    <PhyNetGroup/>
+  </Step>
+</IPC-2581>`;
+    const f = path.join(tempDir, "passive-nogeo.xml");
+    writeFileSync(f, xml);
+    const result = await queryComponent(f, "C9");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.parsed).toBeDefined();
+      expect(result.parsed!.packageFamily).toBe("C");
+      expect(result.parsed!.pinCount).toBeUndefined();
+    }
+  });
+
   it("deduplicates identical pad shapes", async () => {
     const xml = `<IPC-2581>
   <Content>
@@ -263,6 +374,64 @@ describe("queryComponent -- pad geometry", () => {
       for (const row of result.padRows!) {
         expect(row[3]).toBe(0);
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-world chip passives (issues #38 / #40) on a Cadence Allegro export.
+// Ground truth: every chip passive is a two-terminal part, so pinCount must be
+// 2 and pad geometry must be non-empty -- regardless of the case-size digits in
+// the footprint name.
+// ---------------------------------------------------------------------------
+describe.skipIf(!hasParallellaFixture)("queryComponent -- parallella passives", () => {
+  it("reports pinCount 2 and two pads for a chip capacitor (C0402)", async () => {
+    const result = await queryComponent(PARALLELLA_REVB, "C162");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.packageRef).toMatch(/^C0402/);
+      expect(result.parsed).toBeDefined();
+      expect(result.parsed!.pinCount).toBe(2);
+      expect(result.padRows).toBeDefined();
+      expect(result.padRows!.length).toBe(2);
+    }
+  });
+
+  it("reports pinCount 2 for a ferrite bead (F0603)", async () => {
+    const result = await queryComponent(PARALLELLA_REVB, "F1");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.parsed).toBeDefined();
+      expect(result.parsed!.pinCount).toBe(2);
+    }
+  });
+
+  it("keeps an authoritative pin count for a multi-pin IC (TSSOP24)", async () => {
+    const result = await queryComponent(PARALLELLA_REVB, "U37");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.parsed).toBeDefined();
+      expect(result.parsed!.packageFamily).toBe("TSSOP");
+      expect(result.parsed!.pinCount).toBe(24);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-world chip passives whose pads are defined as <Contour><Polygon> shapes
+// (issue #40, the encoding used by this Cadence RevC export). R1 is a chip
+// resistor in the SR0603_85 land pattern: two pads, pinCount 2.
+// ---------------------------------------------------------------------------
+describe.skipIf(!hasTestcase1Fixture)("queryComponent -- testcase1 RevC contour pads", () => {
+  it("returns two pads and pinCount 2 for a chip resistor with polygon pads", async () => {
+    const result = await queryComponent(TESTCASE1_REVC, "R1");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      expect(result.packageRef).toMatch(/^SR0603/);
+      expect(result.parsed!.pinCount).toBe(2);
+      expect(result.padRows).toBeDefined();
+      expect(result.padRows!.length).toBe(2);
+      expect(result.padShapes!.length).toBeGreaterThan(0);
     }
   });
 });

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -7,6 +7,7 @@ import type {
   NetRow,
   PadRow,
   PadShape,
+  ParsedPackage,
 } from "./lib/types.js";
 import {
   extractShapes,
@@ -15,7 +16,6 @@ import {
   transformPin,
 } from "./lib/geometry.js";
 import { parsePackageRef } from "./lib/package-parser.js";
-import type { ParsedPackage } from "./lib/types.js";
 import { attr, numAttr, loadAllLines, streamAllLines } from "./lib/xml-utils.js";
 import {
   extractMicronFactor,

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -211,9 +211,12 @@ export const queryComponent = async (
           f
         );
         // Prefer the pad's inline shape; fall back to the shape of the
-        // referenced padstack (chip passives often carry only the latter).
+        // referenced padstack (chip passives often carry only the latter). If
+        // neither resolves (e.g. an unknown primitive type), the pad is skipped
+        // rather than emitted without geometry.
         const shapeId =
-          pinDef.shapeId || (pinDef.padstackRef ? padstackShapes.get(pinDef.padstackRef) : undefined);
+          pinDef.shapeId ||
+          (pinDef.padstackRef ? padstackShapes.get(pinDef.padstackRef) : undefined);
         const shape = shapeId ? shapes.get(shapeId) : undefined;
         if (shape) {
           const w = Math.round(shape.width);
@@ -255,11 +258,11 @@ export const queryComponent = async (
 
   const nameParsed = parsePackageRef(p.packageRef);
   const pinCount = authoritativePinCount ?? nameParsed?.pinCount;
+  // parsePackageRef only returns null for empty / letter-less refs (no family to
+  // report), so there is nothing useful to emit in that case even with a pin count.
   const parsed: ParsedPackage | undefined = nameParsed
     ? { ...nameParsed, ...(pinCount !== undefined ? { pinCount } : {}) }
-    : pinCount !== undefined
-      ? { packageFamily: "UNKNOWN", pinCount }
-      : undefined;
+    : undefined;
 
   const netRows: NetRow[] = [...netMap.entries()]
     .sort(([a], [b]) => a.localeCompare(b))

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -8,8 +8,14 @@ import type {
   PadRow,
   PadShape,
 } from "./lib/types.js";
-import { extractShapes, extractPackages, transformPin } from "./lib/geometry.js";
+import {
+  extractShapes,
+  extractPackages,
+  extractPadstackShapes,
+  transformPin,
+} from "./lib/geometry.js";
 import { parsePackageRef } from "./lib/package-parser.js";
+import type { ParsedPackage } from "./lib/types.js";
 import { attr, numAttr, loadAllLines, streamAllLines } from "./lib/xml-utils.js";
 import {
   extractMicronFactor,
@@ -183,6 +189,7 @@ export const queryComponent = async (
     const f = extractMicronFactorFromLines(lines);
     const shapes = extractShapes(lines, f);
     const packages = extractPackages(lines);
+    const padstackShapes = extractPadstackShapes(lines);
 
     const pkg = packages.get(p.packageRef);
     if (pkg) {
@@ -203,7 +210,11 @@ export const queryComponent = async (
           pinDef,
           f
         );
-        const shape = shapes.get(pinDef.shapeId);
+        // Prefer the pad's inline shape; fall back to the shape of the
+        // referenced padstack (chip passives often carry only the latter).
+        const shapeId =
+          pinDef.shapeId || (pinDef.padstackRef ? padstackShapes.get(pinDef.padstackRef) : undefined);
+        const shape = shapeId ? shapes.get(shapeId) : undefined;
         if (shape) {
           const w = Math.round(shape.width);
           const h = Math.round(shape.height);
@@ -223,8 +234,33 @@ export const queryComponent = async (
     }
   }
 
-  // Build result
-  const parsed = parsePackageRef(p.packageRef);
+  // Build result.
+  //
+  // Authoritative pin count comes from geometry, not the package name: prefer the
+  // parsed pad rows (true land-pattern pad count), then fall back to the distinct
+  // pins of this component seen on logical nets. The name-derived count is only a
+  // last resort for families whose name genuinely encodes it (e.g. a BGA whose
+  // pads failed to parse). This keeps chip passives at their real count (2) rather
+  // than the case-size digits the old code reported.
+  const connectedPins = new Set<string>();
+  for (const data of netMap.values()) {
+    for (const pin of data.componentPins) connectedPins.add(pin);
+  }
+  const authoritativePinCount =
+    padRows && padRows.length > 0
+      ? padRows.length
+      : connectedPins.size > 0
+        ? connectedPins.size
+        : undefined;
+
+  const nameParsed = parsePackageRef(p.packageRef);
+  const pinCount = authoritativePinCount ?? nameParsed?.pinCount;
+  const parsed: ParsedPackage | undefined = nameParsed
+    ? { ...nameParsed, ...(pinCount !== undefined ? { pinCount } : {}) }
+    : pinCount !== undefined
+      ? { packageFamily: "UNKNOWN", pinCount }
+      : undefined;
+
   const netRows: NetRow[] = [...netMap.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([netName, data]) => [netName, data.componentPins, data.pinCount]);

--- a/src/tools/lib/geometry.ts
+++ b/src/tools/lib/geometry.ts
@@ -107,6 +107,8 @@ export const extractShapes = (lines: string[], f: number): Map<string, Shape> =>
     }
     // Polygon/Contour pad shapes (common for chip passives in some exports): no
     // width/height attribute, so report the bounding box of the outline points.
+    // We enter on either tag but emit only on </Contour>, matching the standard
+    // <Contour><Polygon>...</Polygon></Contour> wrapper this export uses.
     if (currentId && (line.includes("<Contour") || line.includes("<Polygon"))) {
       inContour = true;
     }

--- a/src/tools/lib/geometry.ts
+++ b/src/tools/lib/geometry.ts
@@ -25,7 +25,8 @@ export interface Shape {
 export interface PinDef {
   offsetX: number;
   offsetY: number;
-  shapeId: string;
+  /** Inline pad shape id; absent when the shape is reached via `padstackRef`. */
+  shapeId?: string;
   /**
    * Padstack referenced by the pad (`padstackDefRef`). Used to resolve the pad
    * shape when the pad has no inline `<StandardPrimitiveRef>` (common for chip
@@ -64,8 +65,14 @@ export const extractShapes = (lines: string[], f: number): Map<string, Shape> =>
   scanLines(lines, (line) => {
     if (line.includes("<EntryStandard ")) {
       currentId = attr(line, "id") ?? "";
+      // Reset the contour state, including the bounding box, so a missing
+      // </Contour> in malformed XML cannot bleed stale bounds into the next shape.
       inContour = false;
       contourPoints = 0;
+      minX = Infinity;
+      minY = Infinity;
+      maxX = -Infinity;
+      maxY = -Infinity;
     }
     // Rectangular primitives (RectCenter and rounded/chamfered/cornered variants)
     // all expose width/height; we model them all as a rectangle.
@@ -103,7 +110,11 @@ export const extractShapes = (lines: string[], f: number): Map<string, Shape> =>
     if (currentId && (line.includes("<Contour") || line.includes("<Polygon"))) {
       inContour = true;
     }
-    if (currentId && inContour && (line.includes("<PolyBegin ") || line.includes("<PolyStepSegment "))) {
+    if (
+      currentId &&
+      inContour &&
+      (line.includes("<PolyBegin ") || line.includes("<PolyStepSegment "))
+    ) {
       const x = numAttr(line, "x");
       const y = numAttr(line, "y");
       if (x !== undefined && y !== undefined) {
@@ -154,7 +165,7 @@ export const extractPackages = (lines: string[]): Map<string, Map<string, PinDef
       packages.get(currentPkg)!.set(padPin, {
         offsetX: padOffset.x,
         offsetY: padOffset.y,
-        shapeId: padShapeId,
+        ...(padShapeId ? { shapeId: padShapeId } : {}),
         ...(padstackRef ? { padstackRef } : {}),
       });
     }
@@ -299,6 +310,8 @@ export const extractPadstackShapes = (lines: string[]): Map<string, string> => {
     if (line.includes("</PadStackDef>")) {
       currentName = "";
     }
+    // PadStackDef elements precede Package definitions in the IPC-2581 CadData
+    // ordering, so stop scanning once packages begin (same as extractViaPadSizes).
     if (line.includes("<Package ")) return false;
   });
 

--- a/src/tools/lib/geometry.ts
+++ b/src/tools/lib/geometry.ts
@@ -17,7 +17,7 @@ export interface Point {
 }
 
 export interface Shape {
-  type: "rect" | "circle";
+  type: "rect" | "circle" | "oval" | "polygon";
   width: number;
   height: number;
 }
@@ -26,6 +26,12 @@ export interface PinDef {
   offsetX: number;
   offsetY: number;
   shapeId: string;
+  /**
+   * Padstack referenced by the pad (`padstackDefRef`). Used to resolve the pad
+   * shape when the pad has no inline `<StandardPrimitiveRef>` (common for chip
+   * passives in some Cadence exports), via `extractPadstackShapes`.
+   */
+  padstackRef?: string;
 }
 
 export interface ComponentPlacement {
@@ -45,16 +51,43 @@ export interface ComponentPlacement {
 export const extractShapes = (lines: string[], f: number): Map<string, Shape> => {
   const shapes = new Map<string, Shape>();
   let currentId = "";
+  // Bounding-box accumulator for polygon/contour pad shapes, which span multiple
+  // lines (a sequence of PolyBegin/PolyStepSegment points) rather than carrying
+  // width/height attributes on a single primitive element.
+  let inContour = false;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let contourPoints = 0;
 
   scanLines(lines, (line) => {
     if (line.includes("<EntryStandard ")) {
       currentId = attr(line, "id") ?? "";
+      inContour = false;
+      contourPoints = 0;
     }
-    if (currentId && line.includes("<RectCenter ")) {
+    // Rectangular primitives (RectCenter and rounded/chamfered/cornered variants)
+    // all expose width/height; we model them all as a rectangle.
+    if (
+      currentId &&
+      (line.includes("<RectCenter ") ||
+        line.includes("<RectRound ") ||
+        line.includes("<RectCham ") ||
+        line.includes("<RectCorner "))
+    ) {
       const w = numAttr(line, "width");
       const h = numAttr(line, "height");
       if (w !== undefined && h !== undefined) {
         shapes.set(currentId, { type: "rect", width: w * f, height: h * f });
+      }
+      currentId = "";
+    }
+    if (currentId && line.includes("<Oval ")) {
+      const w = numAttr(line, "width");
+      const h = numAttr(line, "height");
+      if (w !== undefined && h !== undefined) {
+        shapes.set(currentId, { type: "oval", width: w * f, height: h * f });
       }
       currentId = "";
     }
@@ -63,6 +96,38 @@ export const extractShapes = (lines: string[], f: number): Map<string, Shape> =>
       if (d !== undefined) {
         shapes.set(currentId, { type: "circle", width: d * f, height: d * f });
       }
+      currentId = "";
+    }
+    // Polygon/Contour pad shapes (common for chip passives in some exports): no
+    // width/height attribute, so report the bounding box of the outline points.
+    if (currentId && (line.includes("<Contour") || line.includes("<Polygon"))) {
+      inContour = true;
+    }
+    if (currentId && inContour && (line.includes("<PolyBegin ") || line.includes("<PolyStepSegment "))) {
+      const x = numAttr(line, "x");
+      const y = numAttr(line, "y");
+      if (x !== undefined && y !== undefined) {
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+        contourPoints++;
+      }
+    }
+    if (currentId && inContour && line.includes("</Contour>")) {
+      if (contourPoints > 0 && !shapes.has(currentId)) {
+        shapes.set(currentId, {
+          type: "polygon",
+          width: (maxX - minX) * f,
+          height: (maxY - minY) * f,
+        });
+      }
+      inContour = false;
+      contourPoints = 0;
+      minX = Infinity;
+      minY = Infinity;
+      maxX = -Infinity;
+      maxY = -Infinity;
       currentId = "";
     }
     if (line.includes("</Content>")) return false;
@@ -79,18 +144,24 @@ export const extractPackages = (lines: string[]): Map<string, Map<string, PinDef
   let padPin = "";
   let padOffset: Point = { x: 0, y: 0 };
   let padShapeId = "";
+  let padstackRef = "";
 
   const commitPad = () => {
-    if (currentPkg && padPin && padShapeId) {
+    // Keep the pad if we have either an inline shape or a padstack reference the
+    // caller can resolve later. Chip passives in some exports carry only the
+    // latter, so requiring an inline shape here silently dropped their pads.
+    if (currentPkg && padPin && (padShapeId || padstackRef)) {
       packages.get(currentPkg)!.set(padPin, {
         offsetX: padOffset.x,
         offsetY: padOffset.y,
         shapeId: padShapeId,
+        ...(padstackRef ? { padstackRef } : {}),
       });
     }
     padPin = "";
     padOffset = { x: 0, y: 0 };
     padShapeId = "";
+    padstackRef = "";
   };
 
   scanLines(lines, (line) => {
@@ -111,6 +182,7 @@ export const extractPackages = (lines: string[]): Map<string, Map<string, PinDef
       padPin = "";
       padOffset = { x: 0, y: 0 };
       padShapeId = "";
+      padstackRef = attr(line, "padstackDefRef") ?? "";
     }
     if (inPad) {
       if (line.includes("<PinRef ")) {
@@ -136,6 +208,7 @@ export const extractPackages = (lines: string[]): Map<string, Map<string, PinDef
       padPin = attr(line, "number") ?? "";
       padOffset = { x: 0, y: 0 };
       padShapeId = "";
+      padstackRef = attr(line, "padstackDefRef") ?? "";
     }
     if (inPin) {
       if (line.includes("<Location ")) {
@@ -193,6 +266,43 @@ export const extractViaPadSizes = (
   });
 
   return viaPads;
+};
+
+/**
+ * Map of padstack name -> the shape id of its REGULAR (copper) pad.
+ *
+ * Used to resolve a pad's shape when the pad references a padstack
+ * (`padstackDefRef`) instead of carrying an inline `<StandardPrimitiveRef>`.
+ * Unlike `extractViaPadSizes`, this does not require a drilled hole, so it also
+ * covers surface-mount pads (e.g. chip-passive land patterns).
+ */
+export const extractPadstackShapes = (lines: string[]): Map<string, string> => {
+  const padstacks = new Map<string, string>();
+  let currentName = "";
+  let foundRegular = false;
+
+  scanLines(lines, (line) => {
+    if (line.includes("<PadStackDef ")) {
+      currentName = attr(line, "name") ?? "";
+      foundRegular = false;
+    }
+    if (currentName && !foundRegular && line.includes('padUse="REGULAR"')) {
+      foundRegular = true;
+    }
+    if (currentName && foundRegular && line.includes("<StandardPrimitiveRef ")) {
+      const id = attr(line, "id") ?? "";
+      if (id && !padstacks.has(currentName)) {
+        padstacks.set(currentName, id);
+      }
+      foundRegular = false;
+    }
+    if (line.includes("</PadStackDef>")) {
+      currentName = "";
+    }
+    if (line.includes("<Package ")) return false;
+  });
+
+  return padstacks;
 };
 
 export const extractComponents = (lines: string[], f: number): ComponentPlacement[] => {

--- a/src/tools/lib/package-parser.test.ts
+++ b/src/tools/lib/package-parser.test.ts
@@ -46,25 +46,59 @@ describe("parsePackageRef", () => {
     expect(result!.bodySize_mm).toBeUndefined();
   });
 
-  it("parses simple resistor package", () => {
+  it("parses whitelisted IC family with a true pin count (SOIC8)", () => {
+    const result = parsePackageRef("SOIC8");
+    expect(result).not.toBeNull();
+    expect(result!.packageFamily).toBe("SOIC");
+    expect(result!.pinCount).toBe(8);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chip passives and JEDEC-coded families: the trailing digits are a case-size
+  // or package code, NOT a pin count. The family is surfaced but pinCount is
+  // left undefined for the caller to derive from geometry (issue #38).
+  // ---------------------------------------------------------------------------
+  it("does not treat a chip-resistor case size as a pin count", () => {
     const result = parsePackageRef("RES0402");
     expect(result).not.toBeNull();
     expect(result!.packageFamily).toBe("RES");
-    expect(result!.pinCount).toBe(402);
+    expect(result!.pinCount).toBeUndefined();
   });
 
-  it("parses SOT with pin count", () => {
+  it("does not treat chip cap / inductor / ferrite case sizes as pin counts", () => {
+    for (const [ref, family] of [
+      ["CAP0402", "CAP"],
+      ["C0402", "C"],
+      ["IND0201", "IND"],
+      ["INDP0603", "INDP"],
+      ["F0603", "F"],
+    ] as const) {
+      const result = parsePackageRef(ref);
+      expect(result).not.toBeNull();
+      expect(result!.packageFamily).toBe(family);
+      expect(result!.pinCount).toBeUndefined();
+    }
+  });
+
+  it("does not treat a SOT JEDEC code as a pin count", () => {
     const result = parsePackageRef("SOT23");
     expect(result).not.toBeNull();
     expect(result!.packageFamily).toBe("SOT");
-    expect(result!.pinCount).toBe(23);
+    expect(result!.pinCount).toBeUndefined();
   });
 
-  it("parses CAPAE (aluminum electrolytic)", () => {
+  it("does not treat CAPAE body dimensions as a pin count", () => {
     const result = parsePackageRef("CAPAE660X610");
     expect(result).not.toBeNull();
     expect(result!.packageFamily).toBe("CAPAE");
-    expect(result!.pinCount).toBe(660);
+    expect(result!.pinCount).toBeUndefined();
+  });
+
+  it("surfaces the family even when the name has no trailing digits", () => {
+    const result = parsePackageRef("DIODEM");
+    expect(result).not.toBeNull();
+    expect(result!.packageFamily).toBe("DIODEM");
+    expect(result!.pinCount).toBeUndefined();
   });
 
   // ---------------------------------------------------------------------------

--- a/src/tools/lib/package-parser.ts
+++ b/src/tools/lib/package-parser.ts
@@ -14,12 +14,57 @@
 
 export interface ParsedPackage {
   packageFamily: string;
-  pinCount: number;
+  /**
+   * Pin/pad count, only when the package name is an authoritative source for it.
+   * The full Cadence format encodes it explicitly; for the simple format it is
+   * trusted only for families where the leading number is genuinely a pin/ball
+   * count (see PIN_COUNT_FAMILIES). For chip passives (RES/CAP/IND/INDP) and
+   * packages like SOT/CAPAE the trailing digits are an imperial case-size or
+   * JEDEC code, not a pin count, so this is left undefined and the caller should
+   * derive the count from pad/net geometry instead.
+   */
+  pinCount?: number;
   bodySize_mm?: { width: number; height: number };
   pitch_mm?: number;
   ballHeight_mm?: number;
   ubmDiameter_mm?: number;
 }
+
+/**
+ * Families where the digits immediately after the family prefix in the simple
+ * footprint name denote the pin/ball count (e.g. BGA256, QFN48, SOIC8).
+ *
+ * Deliberately excludes chip passives (RES/CAP/IND/INDP/FER/FB) and families
+ * whose trailing number is a case-size or JEDEC package code rather than a pin
+ * count (e.g. SOT23, CAPAE). For those the count must come from pad/net geometry.
+ */
+const PIN_COUNT_FAMILIES = new Set([
+  "BGA",
+  "CBGA",
+  "PBGA",
+  "FBGA",
+  "UBGA",
+  "WLCSP",
+  "CSP",
+  "QFN",
+  "VQFN",
+  "QFP",
+  "TQFP",
+  "LQFP",
+  "MQFP",
+  "DFN",
+  "SON",
+  "LGA",
+  "SOIC",
+  "SOP",
+  "SSOP",
+  "TSSOP",
+  "TSOP",
+  "MSOP",
+  "HSOP",
+  "DIP",
+  "PLCC",
+]);
 
 /**
  * Convert a Cadence P-as-decimal number to a real number.
@@ -38,8 +83,11 @@ const cadenceToMm = (raw: string): number => parseInt(raw, 10) / 100;
 //   group 6: component height (after second X)
 const CADENCE_FULL = /^([A-Z]+?)(\d+)C(\d+)P\d+X\d+_(\d+)X(\d+)X(\d+)$/i;
 
-// Simpler variant: BGA256_1MM or PKG123 (family + pin count only)
+// Simpler variant: BGA256_1MM or PKG123 (family + trailing number)
 const CADENCE_SIMPLE = /^([A-Z]+?)(\d+)/i;
+
+// Family token only, no trailing digits (e.g. DIODEM, TESTPOINT)
+const FAMILY_ONLY = /^([A-Za-z]+)/;
 
 export const parsePackageRef = (packageRef: string): ParsedPackage | null => {
   const fullMatch = CADENCE_FULL.exec(packageRef);
@@ -60,13 +108,22 @@ export const parsePackageRef = (packageRef: string): ParsedPackage | null => {
   const simpleMatch = CADENCE_SIMPLE.exec(packageRef);
   if (simpleMatch) {
     const [, family, pins] = simpleMatch;
+    const fam = family.toUpperCase();
     const pinCount = parseInt(pins, 10);
-    if (pinCount > 0) {
-      return {
-        packageFamily: family.toUpperCase(),
-        pinCount,
-      };
+    // Only trust the trailing number as a pin count for families where it
+    // genuinely encodes one. For everything else (chip passives, SOT, CAPAE,
+    // ...) surface the family but leave pinCount for geometry to determine.
+    if (PIN_COUNT_FAMILIES.has(fam) && pinCount > 0) {
+      return { packageFamily: fam, pinCount };
     }
+    return { packageFamily: fam };
+  }
+
+  // No trailing digits: still surface the family so `parsed` is emitted
+  // consistently for every component (e.g. DIODEM, TESTPOINT).
+  const familyOnly = FAMILY_ONLY.exec(packageRef);
+  if (familyOnly) {
+    return { packageFamily: familyOnly[1].toUpperCase() };
   }
 
   return null;

--- a/src/tools/lib/package-parser.ts
+++ b/src/tools/lib/package-parser.ts
@@ -12,23 +12,10 @@
  * returns null for unrecognized formats.
  */
 
-export interface ParsedPackage {
-  packageFamily: string;
-  /**
-   * Pin/pad count, only when the package name is an authoritative source for it.
-   * The full Cadence format encodes it explicitly; for the simple format it is
-   * trusted only for families where the leading number is genuinely a pin/ball
-   * count (see PIN_COUNT_FAMILIES). For chip passives (RES/CAP/IND/INDP) and
-   * packages like SOT/CAPAE the trailing digits are an imperial case-size or
-   * JEDEC code, not a pin count, so this is left undefined and the caller should
-   * derive the count from pad/net geometry instead.
-   */
-  pinCount?: number;
-  bodySize_mm?: { width: number; height: number };
-  pitch_mm?: number;
-  ballHeight_mm?: number;
-  ubmDiameter_mm?: number;
-}
+// ParsedPackage is defined in types.ts (the single source of truth) and
+// re-exported here for callers that import it alongside parsePackageRef.
+import type { ParsedPackage } from "./types.js";
+export type { ParsedPackage };
 
 /**
  * Families where the digits immediately after the family prefix in the simple

--- a/src/tools/lib/package-parser.ts
+++ b/src/tools/lib/package-parser.ts
@@ -24,6 +24,11 @@ export type { ParsedPackage };
  * Deliberately excludes chip passives (RES/CAP/IND/INDP/FER/FB) and families
  * whose trailing number is a case-size or JEDEC package code rather than a pin
  * count (e.g. SOT23, CAPAE). For those the count must come from pad/net geometry.
+ *
+ * This list is intentionally not exhaustive: it covers the common surface-mount
+ * IC families. Edge cases (e.g. SIP<n>, TO<n>) are omitted on purpose -- when a
+ * family is absent the caller still gets the authoritative geometry-derived
+ * count, so the worst case is a missing name hint, never a wrong one.
  */
 const PIN_COUNT_FAMILIES = new Set([
   "BGA",

--- a/src/tools/lib/types.ts
+++ b/src/tools/lib/types.ts
@@ -75,7 +75,14 @@ export interface ComponentInfo {
  */
 export interface ParsedPackage {
   packageFamily: string;
-  pinCount: number;
+  /**
+   * Pin/pad count. Optional because the package name alone is not an authoritative
+   * source: for chip passives (RES/CAP/IND/INDP) and packages like SOT/CAPAE the
+   * trailing digits are an imperial case-size or JEDEC code, not a pin count. When
+   * present here it is the authoritative count derived from pad/net geometry, or a
+   * trusted name-derived count for families where the name genuinely encodes it.
+   */
+  pinCount?: number;
   bodySize_mm?: { width: number; height: number };
   pitch_mm?: number;
   ballHeight_mm?: number;
@@ -86,7 +93,8 @@ export interface ParsedPackage {
  * Unique pad shape definition, referenced by index from pad rows.
  */
 export interface PadShape {
-  shape: "rect" | "circle";
+  /** "polygon" pads are reported by their bounding box (width/height). */
+  shape: "rect" | "circle" | "oval" | "polygon";
   width: number;
   height: number;
 }

--- a/src/tools/render-net.ts
+++ b/src/tools/render-net.ts
@@ -440,7 +440,7 @@ const generateSvg = (data: RenderData, netName: string): string => {
     const pinDef = pkg.get(np.pin);
     if (!pinDef) continue;
     const pos = transformPin(comp, pinDef, factor);
-    const shape = shapes.get(pinDef.shapeId);
+    const shape = pinDef.shapeId ? shapes.get(pinDef.shapeId) : undefined;
     if (!shape) continue;
     const layer = comp.layer || "TOP";
     const color = layerColors.get(layer) ?? "#7f8c8d";
@@ -587,7 +587,7 @@ export const renderNet = async (
     const pkg = packages.get(comp.packageRef);
     if (!pkg) continue;
     const pin = pkg.get(np.pin);
-    if (pin && shapes.has(pin.shapeId)) resolvedPads++;
+    if (pin && pin.shapeId && shapes.has(pin.shapeId)) resolvedPads++;
   }
 
   const svg = generateSvg(


### PR DESCRIPTION
## Summary

Fixes two related defects in `get_pcb_component` for two-terminal chip passives (RES/CAP/IND/INDP) and other footprints. Both are rooted in how package/pad data is parsed from IPC-2581.

### #38 — wrong `parsed.pinCount` for chip passives
`pinCount` was derived from the digits after the family prefix in the package name. For chip passives those digits are the imperial **case-size code** (`0402` → `402`), and when the name had no digits the `parsed` object was dropped entirely.

- `parsePackageRef` now treats the trailing number as a pin count **only** for families where it genuinely is one (`PIN_COUNT_FAMILIES`: BGA/QFN/QFP/SOIC/…). For chip passives, SOT, CAPAE it surfaces the family but no `pinCount`, and it surfaces the family even when the name has no digits.
- `queryComponent` derives an **authoritative** `pinCount` from geometry: pad-row count first, then the distinct connected-pin count, falling back to the name hint only when geometry is unavailable. `parsed` is now emitted consistently for every component.

### #40 — empty `padShapes`/`padRows` for chip passives
Pads were dropped whenever the pad's shape primitive couldn't be resolved.

- `extractShapes` now also handles `Oval`, rounded/chamfered/cornered rectangles, and **`Contour`/`Polygon`** pad shapes (reported by bounding box — the encoding this Cadence RevC export actually uses; 296 such shapes in `testcase1-RevC`).
- Pads can resolve their shape via `padstackDefRef` → `PadStackDef` when there is no inline `<StandardPrimitiveRef>`.

## Validation

- Corrected `package-parser` tests that previously **asserted the bug** (`RES0402`→402, `SOT23`→23, `CAPAE…`→660).
- Added inline regression fixtures: contour pad, padstack-only oval pad, no-geometry passive.
- Added real-fixture checks on `parallella-RevB` and `testcase1-RevC`.
- Native stress test across 40 passives on `testcase1-RevC` (56 MB / 1656 components): **0 wrong pin counts, 0 empty pads** after the fix (was 40 empty pads before). The only non-2 pin counts are genuine 4-terminal inductors, correctly reported with 4 pads.
- `npm run type-check && npm run lint && npm test` all green (161 tests).

Closes #38
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)