### PR TITLE
fix(get_pcb_net): parse <Line> conductor segments for routing data (#39)

### DIFF
--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -297,6 +297,51 @@ describe("queryNet -- routing and vias", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Conductors encoded as <Line> rather than <Polyline> (issue #39). A net routed
+// entirely with <Line> segments previously returned no routing at all.
+// ---------------------------------------------------------------------------
+describe("queryNet -- <Line> conductor routing", () => {
+  const LINE_XML = `<IPC-2581>
+  <Content>
+    <EntryLineDesc id="LD_SIG"><LineDesc lineWidth="0.10"/></EntryLineDesc>
+  </Content>
+  <CadHeader units="MILLIMETER"/>
+  <LogicalNet name="SIG1">
+    <PinRef pin="1" componentRef="U1"/>
+    <PinRef pin="2" componentRef="U2"/>
+  </LogicalNet>
+  <Step>
+    <PhyNetGroup/>
+    <LayerFeature layerRef="TOP">
+      <Set net="SIG1">
+        <Features>
+          <Line startX="0" startY="0" endX="3" endY="4"><LineDescRef id="LD_SIG"/></Line>
+        </Features>
+      </Set>
+    </LayerFeature>
+  </Step>
+</IPC-2581>`;
+
+  let lineXml: string;
+  beforeAll(() => {
+    lineXml = path.join(tempDir, "line-routed.xml");
+    writeFileSync(lineXml, LINE_XML);
+  });
+
+  it("returns routing for a net routed with <Line> segments", async () => {
+    const r = expectSuccess(await queryNet(lineXml, "^SIG1$"));
+    const net = r.matches[0];
+    expect(net.routing).toBeDefined();
+    const top = net.routing!.find((rt) => rt.layerName === "TOP");
+    expect(top).toBeDefined();
+    expect(top!.segmentCount).toBe(1);
+    expect(top!.traceWidths).toContain(100); // 0.10mm -> 100 micron
+    expect(top!.traceLength).toBe(5000); // 3-4-5 triangle: 5mm -> 5000 micron
+    expect(net.totalTraceLength).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 describe("queryNet -- edge cases", () => {

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -9,6 +9,8 @@ import type { QueryNetsResult } from "./lib/types.js";
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../../test/fixtures");
 const BEAGLEBONE = path.join(FIXTURE_DIR, "BeagleBone_Black_RevB6.xml");
 const hasBeagleBoneFixture = existsSync(BEAGLEBONE);
+const TESTCASE1_REVC = path.join(FIXTURE_DIR, "testcase1-RevC.xml");
+const hasTestcase1Fixture = existsSync(TESTCASE1_REVC);
 
 // ---------------------------------------------------------------------------
 // Inline fixture -- covers LogicalNet pins, PhyNetPoint layers, LayerFeature
@@ -338,6 +340,26 @@ describe("queryNet -- <Line> conductor routing", () => {
     expect(top!.traceWidths).toContain(100); // 0.10mm -> 100 micron
     expect(top!.traceLength).toBe(5000); // 3-4-5 triangle: 5mm -> 5000 micron
     expect(net.totalTraceLength).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-fixture regression guard for <Line> routing (issue #39). On testcase1
+// RevC the net UN21RES96PA0 is routed on TOP with a mix of <Polyline> and
+// <Line> segments; the 180-micron trace width is contributed only by the
+// <Line> segments, so its presence proves they are now parsed.
+// ---------------------------------------------------------------------------
+describe.skipIf(!hasTestcase1Fixture)("queryNet -- <Line> routing on testcase1 RevC", () => {
+  it("includes the <Line>-only trace width and extra segments for UN21RES96PA0", async () => {
+    const r = expectSuccess(await queryNet(TESTCASE1_REVC, "^UN21RES96PA0$"));
+    const net = r.matches[0];
+    expect(net.routing).toBeDefined();
+    const top = net.routing!.find((rt) => rt.layerName === "TOP");
+    expect(top).toBeDefined();
+    // 180 micron appears only once <Line> segments are parsed (was [300, 500]).
+    expect(top!.traceWidths).toContain(180);
+    // TOP previously reported 3 segments (polylines only); <Line> segments add more.
+    expect(top!.segmentCount).toBeGreaterThan(3);
   });
 });
 

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -188,6 +188,8 @@ export const queryNet = async (
       // Conductor segments encoded as <Line startX startY endX endY> rather than
       // a <Polyline>. Cadence uses these for single-segment traces; a net routed
       // entirely with <Line> elements previously returned no routing at all.
+      // Only conductor layers reach here (skipLayers excludes REF-route/REF-both),
+      // and a Line is only counted when it carries start/end coordinates.
       if (line.includes("<Line ")) {
         const sx = numAttr(line, "startX");
         const sy = numAttr(line, "startY");

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -124,7 +124,7 @@ export const queryNet = async (
   let currentLayerName = "";
   let insideMatchedSet = false;
   let currentSetNetName = "";
-  let currentSetHasPolyline = false;
+  let currentSetHasConductor = false;
   let currentSetLineDescId: string | undefined;
   let currentSetInlineWidth: number | undefined;
   let inPolyline = false;
@@ -142,7 +142,7 @@ export const queryNet = async (
         netName && matchedNames.has(netName) && !skipLayers.has(currentLayerName)
       );
       currentSetNetName = netName ?? "";
-      currentSetHasPolyline = false;
+      currentSetHasConductor = false;
       currentSetLineDescId = undefined;
       currentSetInlineWidth = undefined;
       polyLength = 0;
@@ -160,7 +160,7 @@ export const queryNet = async (
       }
 
       if (line.includes("<Polyline")) {
-        currentSetHasPolyline = true;
+        currentSetHasConductor = true;
         inPolyline = true;
         polyPoints = [];
       }
@@ -182,6 +182,22 @@ export const queryNet = async (
         }
         if (line.includes("</Polyline>")) {
           inPolyline = false;
+        }
+      }
+
+      // Conductor segments encoded as <Line startX startY endX endY> rather than
+      // a <Polyline>. Cadence uses these for single-segment traces; a net routed
+      // entirely with <Line> elements previously returned no routing at all.
+      if (line.includes("<Line ")) {
+        const sx = numAttr(line, "startX");
+        const sy = numAttr(line, "startY");
+        const ex = numAttr(line, "endX");
+        const ey = numAttr(line, "endY");
+        if (sx !== undefined && sy !== undefined && ex !== undefined && ey !== undefined) {
+          currentSetHasConductor = true;
+          const dx = (ex - sx) * factor;
+          const dy = (ey - sy) * factor;
+          polyLength += Math.sqrt(dx * dx + dy * dy);
         }
       }
 
@@ -214,7 +230,7 @@ export const queryNet = async (
       }
 
       if (line.includes("</Set>")) {
-        if (currentSetHasPolyline && currentLayerName) {
+        if (currentSetHasConductor && currentLayerName) {
           if (!acc.routeMap.has(currentLayerName)) {
             acc.routeMap.set(currentLayerName, { widths: new Set(), segments: 0, traceLength: 0 });
           }


### PR DESCRIPTION
## Summary

`get_pcb_net`'s description promises per-layer **trace widths, trace lengths, and segment counts**, but the routing parser only handled `<Polyline>` conductors. Cadence Allegro also encodes traces as `<Line startX startY endX endY>` segments, which were silently ignored:

- nets routed **partly** with `<Line>` had their segment counts and lengths undercounted, and
- nets routed **entirely** with `<Line>` returned **no routing at all** — the exact symptom in #39.

## Fix

`<Line>` segments are now accumulated into the same per-layer `routeMap` as polylines: each segment's Euclidean length is added, and its width comes from the `<LineDescRef>` / inline `<LineDesc>` the parser already reads. The per-set flag was renamed `currentSetHasConductor` since it now covers both encodings.

## Validation

- New inline regression test: a net routed purely with a `<Line>` segment now returns routing (segment count, 100 µm width, 5000 µm length from a 3-4-5 triangle). Before this change it returned no routing.
- Native check on `testcase1-RevC` (56 MB): net `UN21RES96PA0` went from **4 → 7** routed segments and its TOP layer picked up a previously-missing **180 µm** trace width.
- `npm run type-check && npm run lint && npm test` all green (152 tests). Integration snapshots unaffected.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)