### PR TITLE
fix(token-budget): tighten detail=full coordinate cap to a few hundred rows

### DIFF
--- a/docs/tools/get_pcb_component.md
+++ b/docs/tools/get_pcb_component.md
@@ -6,7 +6,7 @@ Look up a single component by exact refdes. Returns placement, package, BOM data
 
 Look up a single component by exact refdes in an IPC-2581 file. Returns placement (x/y/rotation/layer/mount type), package (with parsed Cadence package details when recognizable), BOM data (description and characteristics like value, tolerance, etc.), connected nets with the component's pin names, and a pad-geometry summary (pad count + deduped pad shapes). Pass `detail="full"` for per-pin pad coordinates. Useful for inspecting a specific IC, capacitor, or resistor.
 
-Responses are token-bounded by design: the per-pin pad coordinate array (`padRows`) is heavy for high-pin-count parts, so it is omitted by default in favor of `padCount` + `padShapes`. Callers that need every pad coordinate pass `detail="full"`; even then the array is capped to a few hundred rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even for the highest-pin-count parts.
+Responses are token-bounded by design: the per-pin pad coordinate array (`padRows`) is heavy for high-pin-count parts, so it is omitted by default in favor of `padCount` + `padShapes`. Callers that need every pad coordinate pass `detail="full"`; even then the array is capped to 300 rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even for the highest-pin-count parts.
 
 ## Input Parameters
 
@@ -190,6 +190,6 @@ Response:
 - Coordinates and dimensions are normalized to microns; rotation is in degrees counterclockwise.
 - `parsed` is present whenever a package family can be derived from `packageRef`. Its `pinCount` is the authoritative count from pad/net geometry (not the case-size digits in the footprint name); it is omitted only when no count can be determined.
 - `netRows` lists each net the component connects to, the component's pins on that net, and the net's total pin count; rows are sorted by net name.
-- `padCount` and `padShapes` are present whenever pad geometry resolves. The per-pin `padColumns`/`padRows` coordinates are returned only with `detail="full"`, sorted by pin, and capped to a few hundred rows (with `truncated: true`) to keep responses token-bounded. Pad shapes defined as a polygon/contour are reported by their bounding box (`shape: "polygon"`).
+- `padCount` and `padShapes` are present whenever pad geometry resolves. The per-pin `padColumns`/`padRows` coordinates are returned only with `detail="full"`, sorted by pin, and capped to 300 rows (with `truncated: true`) to keep responses token-bounded. Pad shapes defined as a polygon/contour are reported by their bounding box (`shape: "polygon"`).
 - The `characteristics` record contains key-value pairs from the BOM (varies by design, common keys include VALUE, TOL, VOLTAGE).
 - `mountType` and `description` may be absent if the IPC-2581 file omits them.

--- a/docs/tools/get_pcb_component.md
+++ b/docs/tools/get_pcb_component.md
@@ -6,7 +6,7 @@ Look up a single component by exact refdes. Returns placement, package, BOM data
 
 Look up a single component by exact refdes in an IPC-2581 file. Returns placement (x/y/rotation/layer/mount type), package (with parsed Cadence package details when recognizable), BOM data (description and characteristics like value, tolerance, etc.), connected nets with the component's pin names, and a pad-geometry summary (pad count + deduped pad shapes). Pass `detail="full"` for per-pin pad coordinates. Useful for inspecting a specific IC, capacitor, or resistor.
 
-Responses are token-bounded by design: the per-pin pad coordinate array (`padRows`) is heavy for high-pin-count parts, so it is omitted by default in favor of `padCount` + `padShapes`. Callers that need every pad coordinate pass `detail="full"`; even then the array is capped (with `truncated: true` set) to stay within a safe size.
+Responses are token-bounded by design: the per-pin pad coordinate array (`padRows`) is heavy for high-pin-count parts, so it is omitted by default in favor of `padCount` + `padShapes`. Callers that need every pad coordinate pass `detail="full"`; even then the array is capped to a few hundred rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even for the highest-pin-count parts.
 
 ## Input Parameters
 
@@ -190,6 +190,6 @@ Response:
 - Coordinates and dimensions are normalized to microns; rotation is in degrees counterclockwise.
 - `parsed` is present whenever a package family can be derived from `packageRef`. Its `pinCount` is the authoritative count from pad/net geometry (not the case-size digits in the footprint name); it is omitted only when no count can be determined.
 - `netRows` lists each net the component connects to, the component's pins on that net, and the net's total pin count; rows are sorted by net name.
-- `padCount` and `padShapes` are present whenever pad geometry resolves. The per-pin `padColumns`/`padRows` coordinates are returned only with `detail="full"`, sorted by pin, and capped (with `truncated: true`) to keep responses token-bounded. Pad shapes defined as a polygon/contour are reported by their bounding box (`shape: "polygon"`).
+- `padCount` and `padShapes` are present whenever pad geometry resolves. The per-pin `padColumns`/`padRows` coordinates are returned only with `detail="full"`, sorted by pin, and capped to a few hundred rows (with `truncated: true`) to keep responses token-bounded. Pad shapes defined as a polygon/contour are reported by their bounding box (`shape: "polygon"`).
 - The `characteristics` record contains key-value pairs from the BOM (varies by design, common keys include VALUE, TOL, VOLTAGE).
 - `mountType` and `description` may be absent if the IPC-2581 file omits them.

--- a/docs/tools/get_pcb_net.md
+++ b/docs/tools/get_pcb_net.md
@@ -8,7 +8,7 @@ Query nets by name pattern in an IPC-2581 file. Returns grouped connected pins, 
 
 Finds all nets whose names match the given regex pattern, then collects connectivity and routing data for each match. Pin connectivity is grouped by component refdes to reduce response size. Empty routing/via fields and zero-value summary fields are omitted to keep payloads compact.
 
-Responses are token-bounded by design. By default (`detail="summary"`) the per-via coordinate array is replaced by `viaCounts` (a count per drill type + layer), so a query never balloons the caller's context. Callers that need every via coordinate pass `detail="full"`; even then the raw array is capped (with `truncated: true` set) to stay within a safe size.
+Responses are token-bounded by design. By default (`detail="summary"`) the per-via coordinate array is replaced by `viaCounts` (a count per drill type + layer), so a query never balloons the caller's context. Callers that need every via coordinate pass `detail="full"`; even then the raw `viaRows` array is capped to a few hundred rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even on the largest nets. The connected-pin list has its own, higher cap, so connectivity on high-fanout nets is not lost to the much smaller coordinate budget.
 
 If a pattern matches all nets in a design (for example `.`, `.*`, or `.+`), the tool rejects the query and asks for a more specific pattern.
 
@@ -209,7 +209,7 @@ Response (`viaColumns`/`viaRows` now present; each `viaRows` entry's `drillIndex
 - Reference layers (`REF-route`, `REF-both`) are skipped to avoid counting template geometry
 - `traceWidths` contains unique widths found on each layer (not one entry per segment)
 - Routing is parsed from `<Polyline>` and `<Line>` centerline conductors and from poured copper shapes (`<Contour>`/`<Polygon>`). Centerline conductors contribute trace widths and lengths; poured shapes contribute only layer presence and a segment count (no centerline width or length), so a net poured as filled copper still reports as routed
-- Vias are collected from `Hole` elements with `platingStatus="VIA"`. By default they are summarized as `viaCounts` (count per unique drill type + layer). With `detail="full"`, `viaRows` carry per-via coordinates and each row's `drillIndex` references `viaCounts` by position; the raw `viaRows` array is capped (with `truncated: true`) to keep responses token-bounded
+- Vias are collected from `Hole` elements with `platingStatus="VIA"`. By default they are summarized as `viaCounts` (count per unique drill type + layer). With `detail="full"`, `viaRows` carry per-via coordinates and each row's `drillIndex` references `viaCounts` by position; the raw `viaRows` array is capped to a few hundred rows (with `truncated: true`) to keep responses token-bounded
 - On extreme-fanout nets the connected-pin list is capped (to at most a fixed number of pins) before being grouped into the `pins` map, setting `truncated: true`; `pinCount` always reports the true total connected-pin count
 - All physical values are normalized to microns
 - `layersUsed` merges layers from PhyNet points and routing geometry

--- a/docs/tools/get_pcb_net.md
+++ b/docs/tools/get_pcb_net.md
@@ -8,7 +8,7 @@ Query nets by name pattern in an IPC-2581 file. Returns grouped connected pins, 
 
 Finds all nets whose names match the given regex pattern, then collects connectivity and routing data for each match. Pin connectivity is grouped by component refdes to reduce response size. Empty routing/via fields and zero-value summary fields are omitted to keep payloads compact.
 
-Responses are token-bounded by design. By default (`detail="summary"`) the per-via coordinate array is replaced by `viaCounts` (a count per drill type + layer), so a query never balloons the caller's context. Callers that need every via coordinate pass `detail="full"`; even then the raw `viaRows` array is capped to a few hundred rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even on the largest nets. The connected-pin list has its own, higher cap, so connectivity on high-fanout nets is not lost to the much smaller coordinate budget.
+Responses are token-bounded by design. By default (`detail="summary"`) the per-via coordinate array is replaced by `viaCounts` (a count per drill type + layer), so a query never balloons the caller's context. Callers that need every via coordinate pass `detail="full"`; even then the raw `viaRows` array is capped to 300 rows (with `truncated: true` set) so a `detail="full"` response stays within a tool-response budget even on the largest nets. The connected-pin list has its own, higher cap, so connectivity on high-fanout nets is not lost to the much smaller coordinate budget.
 
 If a pattern matches all nets in a design (for example `.`, `.*`, or `.+`), the tool rejects the query and asks for a more specific pattern.
 
@@ -209,7 +209,7 @@ Response (`viaColumns`/`viaRows` now present; each `viaRows` entry's `drillIndex
 - Reference layers (`REF-route`, `REF-both`) are skipped to avoid counting template geometry
 - `traceWidths` contains unique widths found on each layer (not one entry per segment)
 - Routing is parsed from `<Polyline>` and `<Line>` centerline conductors and from poured copper shapes (`<Contour>`/`<Polygon>`). Centerline conductors contribute trace widths and lengths; poured shapes contribute only layer presence and a segment count (no centerline width or length), so a net poured as filled copper still reports as routed
-- Vias are collected from `Hole` elements with `platingStatus="VIA"`. By default they are summarized as `viaCounts` (count per unique drill type + layer). With `detail="full"`, `viaRows` carry per-via coordinates and each row's `drillIndex` references `viaCounts` by position; the raw `viaRows` array is capped to a few hundred rows (with `truncated: true`) to keep responses token-bounded
+- Vias are collected from `Hole` elements with `platingStatus="VIA"`. By default they are summarized as `viaCounts` (count per unique drill type + layer). With `detail="full"`, `viaRows` carry per-via coordinates and each row's `drillIndex` references `viaCounts` by position; the raw `viaRows` array is capped to 300 rows (with `truncated: true`) to keep responses token-bounded
 - On extreme-fanout nets the connected-pin list is capped (to at most a fixed number of pins) before being grouped into the `pins` map, setting `truncated: true`; `pinCount` always reports the true total connected-pin count
 - All physical values are normalized to microns
 - `layersUsed` merges layers from PhyNet points and routing geometry

--- a/src/tools/get-pcb-component.test.ts
+++ b/src/tools/get-pcb-component.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { queryComponent } from "./get-pcb-component.js";
 import { isErrorResult } from "./lib/types.js";
-import { MAX_DETAIL_ROWS } from "./shared.js";
+import { MAX_COORD_ROWS } from "./shared.js";
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../../test/fixtures");
 const BEAGLEBONE_REVB6 = path.join(FIXTURE_DIR, "BeagleBone_Black_RevB6.xml");
@@ -370,7 +370,7 @@ describe("queryComponent -- pad geometry", () => {
   // Even detail="full" caps the raw padRows array and flags truncated, while
   // padCount still reports the true pad total.
   it("caps padRows at the budget and flags truncated (detail=full)", async () => {
-    const PAD_COUNT = MAX_DETAIL_ROWS + 100;
+    const PAD_COUNT = MAX_COORD_ROWS + 100;
     const pins = Array.from(
       { length: PAD_COUNT },
       (_, i) => `<Pin number="${i + 1}"><Location x="0" y="0"/><StandardPrimitiveRef id="P"/></Pin>`
@@ -394,7 +394,7 @@ describe("queryComponent -- pad geometry", () => {
     expect(isErrorResult(result)).toBe(false);
     if (!isErrorResult(result)) {
       expect(result.padCount).toBe(PAD_COUNT); // true total preserved
-      expect(result.padRows!.length).toBe(MAX_DETAIL_ROWS); // capped
+      expect(result.padRows!.length).toBe(MAX_COORD_ROWS); // capped
       expect(result.truncated).toBe(true);
     }
   });

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -19,6 +19,7 @@ import { parsePackageRef } from "./lib/package-parser.js";
 import { attr, numAttr, loadAllLines, streamAllLines } from "./lib/xml-utils.js";
 import {
   capDetailRows,
+  MAX_COORD_ROWS,
   extractMicronFactor,
   extractMicronFactorFromLines,
   formatResult,
@@ -278,7 +279,7 @@ export const queryComponent = async (
   if (padShapes && padRows) {
     padFields = { padCount: padRows.length, padShapes };
     if (detail === "full") {
-      const capped = capDetailRows(padRows);
+      const capped = capDetailRows(padRows, MAX_COORD_ROWS);
       padFields.padColumns = ["pin", "x", "y", "shapeIndex"];
       padFields.padRows = capped.rows;
       if (capped.truncated) padFields.truncated = true;

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { queryNet } from "./get-pcb-net.js";
 import { isErrorResult } from "./lib/types.js";
 import type { QueryNetsResult } from "./lib/types.js";
-import { MAX_DETAIL_ROWS } from "./shared.js";
+import { MAX_COORD_ROWS, MAX_PIN_ROWS } from "./shared.js";
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../../test/fixtures");
 const BEAGLEBONE = path.join(FIXTURE_DIR, "BeagleBone_Black_RevB6.xml");
@@ -554,7 +554,7 @@ describe("queryNet -- token bounding", () => {
   });
 
   it("caps raw via rows at the budget and flags truncated (detail=full)", async () => {
-    const VIA_COUNT = MAX_DETAIL_ROWS + 100;
+    const VIA_COUNT = MAX_COORD_ROWS + 100;
     const holes = Array.from(
       { length: VIA_COUNT },
       (_, i) => `<Hole platingStatus="VIA" x="${i}" y="${i}" diameter="0.3"/>`
@@ -584,13 +584,16 @@ describe("queryNet -- token bounding", () => {
     const full = expectSuccess(await queryNet(f, "^BIGNET$", "full"));
     const net = full.matches[0];
     expect(net.totalVias).toBe(VIA_COUNT);
-    expect(net.viaRows!.length).toBe(MAX_DETAIL_ROWS);
+    expect(net.viaRows!.length).toBe(MAX_COORD_ROWS);
     expect(net.truncated).toBe(true);
+    // The whole full response stays small enough for a tool-response budget even
+    // on a net with far more vias than the cap.
+    expect(JSON.stringify(net).length).toBeLessThan(20000);
   });
 
   it("caps the pins map on extreme-fanout nets but reports the true pinCount", async () => {
-    const PIN_COUNT = MAX_DETAIL_ROWS + 100;
-    // One pin each on a distinct refdes -> > MAX_DETAIL_ROWS refdes entries.
+    const PIN_COUNT = MAX_PIN_ROWS + 100;
+    // One pin each on a distinct refdes -> > MAX_PIN_ROWS refdes entries.
     const pinRefs = Array.from(
       { length: PIN_COUNT },
       (_, i) => `<PinRef pin="1" componentRef="U${i}"/>`
@@ -608,7 +611,7 @@ describe("queryNet -- token bounding", () => {
 
     const net = expectSuccess(await queryNet(f, "^WIDENET$")).matches[0];
     expect(net.pinCount).toBe(PIN_COUNT); // true total preserved
-    expect(Object.keys(net.pins).length).toBe(MAX_DETAIL_ROWS); // map capped
+    expect(Object.keys(net.pins).length).toBe(MAX_PIN_ROWS); // map capped
     expect(net.truncated).toBe(true);
   });
 });

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -562,7 +562,11 @@ describe("queryNet -- token bounding", () => {
     const xml = `<IPC-2581>
   <Content></Content>
   <CadHeader units="MILLIMETER"/>
-  <LogicalNet name="BIGNET"><PinRef pin="1" componentRef="U1"/></LogicalNet>
+  <LogicalNet name="BIGNET">
+    <PinRef pin="1" componentRef="U1"/>
+    <PinRef pin="2" componentRef="U2"/>
+    <PinRef pin="3" componentRef="U3"/>
+  </LogicalNet>
   <Step>
     <PhyNetGroup/>
     <LayerFeature layerRef="TOP">
@@ -575,10 +579,14 @@ describe("queryNet -- token bounding", () => {
     const f = path.join(tempDir, "many-vias.xml");
     writeFileSync(f, xml);
 
-    // Summary stays compact regardless of via count.
+    // Summary stays compact regardless of via count, and the coordinate-array
+    // overflow does NOT truncate connectivity: all pins are still returned and the
+    // result is not flagged truncated (the pin list has its own, higher budget).
     const summary = expectSuccess(await queryNet(f, "^BIGNET$"));
     expect(summary.matches[0].totalVias).toBe(VIA_COUNT);
     expect(summary.matches[0]).not.toHaveProperty("viaRows");
+    expect(Object.keys(summary.matches[0].pins)).toEqual(["U1", "U2", "U3"]);
+    expect(summary.matches[0].truncated).toBeFalsy();
 
     // Full mode caps the raw array but still reports the true total.
     const full = expectSuccess(await queryNet(f, "^BIGNET$", "full"));
@@ -586,9 +594,10 @@ describe("queryNet -- token bounding", () => {
     expect(net.totalVias).toBe(VIA_COUNT);
     expect(net.viaRows!.length).toBe(MAX_COORD_ROWS);
     expect(net.truncated).toBe(true);
-    // The whole full response stays small enough for a tool-response budget even
-    // on a net with far more vias than the cap.
-    expect(JSON.stringify(net).length).toBeLessThan(20000);
+    // 300 coord rows serialize to ~18 KB (~4-5k tokens) on the largest known net;
+    // assert the whole full response stays well under a typical tool-response budget
+    // even when the net has far more vias than the cap.
+    expect(JSON.stringify(net).length).toBeLessThan(25_000);
   });
 
   it("caps the pins map on extreme-fanout nets but reports the true pinCount", async () => {

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -14,6 +14,8 @@ import {
   addPin,
   buildLineDescDict,
   capDetailRows,
+  MAX_COORD_ROWS,
+  MAX_PIN_ROWS,
   extractMicronFactor,
   formatResult,
   groupPinsByRefdes,
@@ -337,7 +339,7 @@ export const queryNet = async (
       // list before grouping so we never allocate or return more than the budget,
       // while pinCount still reports the true total.
       const pinCount = acc.pins.length;
-      const cappedPins = capDetailRows(acc.pins);
+      const cappedPins = capDetailRows(acc.pins, MAX_PIN_ROWS);
       const pins = groupPinsByRefdes(cappedPins.rows);
 
       const result: QueryNetResult = {
@@ -356,7 +358,7 @@ export const queryNet = async (
         // included only when the caller opts into detail="full" (capped).
         result.viaCounts = viaCounts;
         if (detail === "full") {
-          const capped = capDetailRows(viaRows);
+          const capped = capDetailRows(viaRows, MAX_COORD_ROWS);
           result.viaColumns = ["x", "y", "drillIndex"];
           result.viaRows = capped.rows;
           if (capped.truncated) result.truncated = true;

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -47,8 +47,12 @@ export const MAX_PIN_ROWS = 2000;
  * whether it was truncated, so callers can surface an explicit `truncated` flag
  * alongside the true total count.
  */
-export const capDetailRows = <T>(rows: T[], cap: number): { rows: T[]; truncated: boolean } =>
-  rows.length > cap ? { rows: rows.slice(0, cap), truncated: true } : { rows, truncated: false };
+export const capDetailRows = <T>(rows: T[], cap: number): { rows: T[]; truncated: boolean } => {
+  const limit = Math.max(0, cap); // defensive: never slice with a negative bound
+  return rows.length > limit
+    ? { rows: rows.slice(0, limit), truncated: true }
+    : { rows, truncated: false };
+};
 
 // =============================================================================
 // File Validation

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -28,7 +28,9 @@ export const formatResult = (result: unknown): { content: { type: "text"; text: 
 //   - MAX_COORD_ROWS: heavy per-coordinate arrays (viaRows/padRows) requested via
 //     detail="full". Each row is a numeric tuple, so a few hundred already cost
 //     thousands of tokens; this is kept low so even a "full" response on the
-//     largest net stays within a typical tool-response budget.
+//     largest net stays within a typical tool-response budget. At 300 rows a full
+//     response is ~18 KB (~4-5k tokens) on the largest known net, a comfortable
+//     margin under common tool-response budgets.
 //   - MAX_PIN_ROWS: the connectivity pin list, which is the core payload of a net
 //     query and far more valuable per row (a short refdes.pin string). It is kept
 //     higher so a high-fanout net (e.g. a 1000+ pin GND) still returns useful

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -22,22 +22,31 @@ export const formatResult = (result: unknown): { content: { type: "text"; text: 
 // context. By default, heavy per-coordinate arrays (per-via, per-pad) are
 // summarized into compact rollups; callers that genuinely need every coordinate
 // pass detail="full". As a hard backstop, even "full" responses cap the raw
-// arrays at MAX_DETAIL_ROWS and flag the result as truncated.
+// arrays and flag the result as truncated.
+//
+// Two caps, because the rows differ in cost and value:
+//   - MAX_COORD_ROWS: heavy per-coordinate arrays (viaRows/padRows) requested via
+//     detail="full". Each row is a numeric tuple, so a few hundred already cost
+//     thousands of tokens; this is kept low so even a "full" response on the
+//     largest net stays within a typical tool-response budget.
+//   - MAX_PIN_ROWS: the connectivity pin list, which is the core payload of a net
+//     query and far more valuable per row (a short refdes.pin string). It is kept
+//     higher so a high-fanout net (e.g. a 1000+ pin GND) still returns useful
+//     connectivity rather than being truncated down to the coordinate budget.
 // =============================================================================
 
 export type Detail = "summary" | "full";
 
-export const MAX_DETAIL_ROWS = 2000;
+export const MAX_COORD_ROWS = 300;
+export const MAX_PIN_ROWS = 2000;
 
 /**
- * Cap a detail array to MAX_DETAIL_ROWS. Returns the (possibly sliced) array and
+ * Cap a detail array to `cap` rows. Returns the (possibly sliced) array and
  * whether it was truncated, so callers can surface an explicit `truncated` flag
  * alongside the true total count.
  */
-export const capDetailRows = <T>(rows: T[]): { rows: T[]; truncated: boolean } =>
-  rows.length > MAX_DETAIL_ROWS
-    ? { rows: rows.slice(0, MAX_DETAIL_ROWS), truncated: true }
-    : { rows, truncated: false };
+export const capDetailRows = <T>(rows: T[], cap: number): { rows: T[]; truncated: boolean } =>
+  rows.length > cap ? { rows: rows.slice(0, cap), truncated: true } : { rows, truncated: false };
 
 // =============================================================================
 // File Validation


### PR DESCRIPTION
## Problem (#41 follow-up)

The reporter confirmed the default/summary path is now bounded, but flagged a residual issue on the opt-in `detail="full"` path: the cap of **2000 coordinate rows** is still ~75-93 KB / ~23k tokens for the largest net (~53k vias), which exceeds a typical tool-response budget and forces persistence-to-disk. The documented "stays within a safe size" promise wasn't actually held at 2000 rows.

## Fix

Split the single `MAX_DETAIL_ROWS = 2000` into **two caps**, because the rows differ in cost and value:

- **`MAX_COORD_ROWS = 300`** — heavy per-coordinate arrays (`viaRows`/`padRows`, `detail="full"`). Each row is a numeric tuple, so a few hundred already cost thousands of tokens. A full `^GND$` query on testcase1-RevC now returns **300 via rows (~18 KB)** instead of 2000 (~93 KB), with `truncated: true` and the true `totalVias` preserved.
- **`MAX_PIN_ROWS = 2000`** — the connectivity pin list (core payload, short `refdes.pin` strings). Kept high so a high-fanout net (1265-pin GND → 806 refdes) still returns **full connectivity** in summary mode rather than being truncated down to the coordinate budget.

> Note: this is a deliberate refinement of "just lower the constant to 300." Lowering the single shared constant globally would also have capped the pins map to 300, silently dropping ~76% of a large GND's connectivity — a regression the reporter never asked for. Splitting addresses the actual `detail="full"` complaint without harming summary connectivity.

`capDetailRows` now takes the cap as a parameter.

## Tests

- The via-cap and pad-cap tests reference `MAX_COORD_ROWS`; the pins-cap test references `MAX_PIN_ROWS` (input `cap + 100`, assert `.toBe(cap)`) — stay green.
- Added a serialized-size assertion: a full response on an over-cap net stays well under a tool-response budget.
- Full suite: 174 passing.

Docs (`get_pcb_net.md`, `get_pcb_component.md`) updated to state the few-hundred-row coordinate cap and the separate, higher connectivity cap.

Addresses #41. Leaving the issue open for the reporter to confirm on their board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)