### PR TITLE
Add OpenTelemetry integration guide to docs/, simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ codex mcp add pcb-lens -- pcb-lens
 
 The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call — a span, the `tool.calls`/`tool.duration`/`tool.errors` metrics, and a correlated log record — so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, working with any compatible backend (OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud service, etc.).
 
-**Disabled by default**, with zero overhead. Turn it on purely with the standard `OTEL_*` environment variables — point `OTEL_EXPORTER_OTLP_ENDPOINT` at your backend and you're done; no code changes. Telemetry never affects tool results.
+**Disabled by default**, with zero overhead. Turn it on purely with the standard `OTEL_*` environment variables — point `OTEL_EXPORTER_OTLP_ENDPOINT` at your backend (and optionally set `OTEL_SERVICE_NAME`); no code changes. Telemetry never affects tool results.
 
 See **[docs/observability.md](docs/observability.md)** for the full signal reference, configuration, and integration guide.
 

--- a/README.md
+++ b/README.md
@@ -114,47 +114,11 @@ codex mcp add pcb-lens -- pcb-lens
 
 ## Observability (OpenTelemetry)
 
-The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral: it works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call — a span, the `tool.calls`/`tool.duration`/`tool.errors` metrics, and a correlated log record — so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, working with any compatible backend (OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud service, etc.).
 
-**Disabled by default.** Telemetry is a no-op with zero overhead unless you set an OTLP endpoint. Turn it on purely with the standard `OTEL_*` environment variables; no code changes and no bespoke config.
+**Disabled by default**, with zero overhead. Turn it on purely with the standard `OTEL_*` environment variables — point `OTEL_EXPORTER_OTLP_ENDPOINT` at your backend and you're done; no code changes. Telemetry never affects tool results.
 
-Each tool call emits:
-
-- a span `tool/<tool_name>` with `tool.name`, `tool.outcome` (`success`/`error`), `tool.duration_ms`, and `error.type` on failure;
-- metrics `tool.calls` (counter), `tool.duration` (ms histogram), and `tool.errors` (counter), labeled by `tool` and `outcome`;
-- a structured log record carrying the active trace/span IDs for trace-to-log correlation.
-
-All telemetry is tagged with `enduser.id`, the host OS account name of whoever is running the server, as a resource attribute (so it appears on traces, metrics, and logs). This attributes usage to the per-session user without any configuration.
-
-### Quick start with a local Collector / Jaeger
-
-Run an all-in-one Jaeger (which accepts OTLP and renders traces) and point the server at it:
-
-```bash
-docker run --rm -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
-
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-export OTEL_SERVICE_NAME=pcb-lens
-# then start the MCP server as usual; open http://localhost:16686 to view traces
-```
-
-### Configuration
-
-Only standard OpenTelemetry environment variables are used:
-
-| Variable | Purpose |
-|----------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint to export to. **Setting this enables telemetry.** |
-| `OTEL_EXPORTER_OTLP_HEADERS` | Headers for the exporter, e.g. `Authorization=Bearer <token>` for a managed backend. |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is not bundled in the standalone binaries and falls back to `http/protobuf`. |
-| `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` | Resource identity. |
-| `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, ... | Standard OTel SDK knobs. |
-
-Additional, clearly-scoped options:
-
-- `OTEL_CAPTURE_TOOL_ARGS=1`: also record raw tool arguments on the span (off by default; arguments may be sensitive).
-
-Telemetry never affects tool results: exporter failures, misconfiguration, or an unreachable backend degrade to "no telemetry", and pending data is flushed on shutdown.
+See **[docs/observability.md](docs/observability.md)** for the full signal reference, configuration, and integration guide.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,10 @@ Once configured, you can ask your AI assistant questions like:
 
 See the [tools/](tools/) directory for detailed documentation on each tool's parameters and response format.
 
+## Observability
+
+The server can emit OpenTelemetry traces, metrics, and logs for every tool call to any OTLP-compatible backend. See [observability.md](observability.md) for the full signal reference, configuration, and integration guide.
+
 ## Error Handling
 
 All tools return an `ErrorResult` on failure:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,149 @@
+# Observability (OpenTelemetry)
+
+The PCB Lens MCP Server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, so it works with any OTLP-compatible backend — an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, and so on.
+
+This is the full developer reference and integration guide. For a one-paragraph summary, see the [root README](../README.md#observability-opentelemetry).
+
+## Design guarantees
+
+- **Disabled by default, zero overhead.** If no OTLP endpoint is configured, the SDK is never imported and instrumentation is a pure pass-through. Enabling telemetry requires no code changes — only standard `OTEL_*` environment variables.
+- **Telemetry never breaks a tool call.** Every span, metric, and log operation is wrapped so that an exporter fault, misconfiguration, or unreachable backend degrades to "no telemetry" — it never surfaces an error to the caller or changes a tool result.
+- **stdout is reserved for MCP.** The server speaks JSON-RPC over stdio, so stdout carries the MCP protocol. All telemetry diagnostics go to **stderr only**, and no console/stdout exporter is ever used.
+- **Flushed on shutdown.** Batched, asynchronous exports are flushed when the process exits (including `SIGINT`/`SIGTERM`), so short-lived invocations do not lose data.
+
+## Signals reference
+
+Each tool call produces one span, updates three metric instruments, and emits one log record. All three signals are correlated and carry the shared resource attributes below.
+
+### Traces
+
+A span named `tool/<tool_name>` (for example, `tool/get_pcb_metadata`) is created for each invocation, with these attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `tool.name` | string | The tool that was invoked, e.g. `get_pcb_net`. |
+| `tool.outcome` | string | `success` or `error`. |
+| `tool.duration_ms` | number | Wall-clock duration of the tool call in milliseconds. |
+| `error.type` | string | Present only on failure. The error name (e.g. `Error`), or `tool_error` when the tool returned a structured error result. |
+| `tool.args` | string | JSON-serialized tool arguments. **Only recorded when `OTEL_CAPTURE_TOOL_ARGS=1`** (off by default; arguments may be sensitive). |
+
+The span status is set to `ERROR` on failure (and the exception is recorded), `OK` otherwise.
+
+### Metrics
+
+| Instrument | Type | Unit | Labels | Description |
+|------------|------|------|--------|-------------|
+| `tool.calls` | counter | — | `tool`, `outcome` | Number of tool invocations. |
+| `tool.duration` | histogram | `ms` | `tool`, `outcome` | Tool invocation duration. |
+| `tool.errors` | counter | — | `tool`, `error_type` | Number of failed tool invocations. |
+
+Metrics are exported periodically (default every 60s — see `OTEL_METRIC_EXPORT_INTERVAL`) and flushed on shutdown.
+
+### Logs
+
+A structured log record is emitted per tool call:
+
+| Field | Value |
+|-------|-------|
+| Body | `tool/<tool_name> <outcome>`, e.g. `tool/get_pcb_net success`. |
+| Severity | `INFO` on success, `ERROR` on failure. |
+| Attributes | `tool.name`, `tool.outcome`, `tool.duration_ms`, `error.type` (on failure), plus `trace_id` and `span_id`. |
+
+The explicit `trace_id` / `span_id` attributes (in addition to the record's own trace context) make trace-to-log correlation straightforward in any backend.
+
+### Resource attributes
+
+These apply to every span, metric, and log record:
+
+| Attribute | Value |
+|-----------|-------|
+| `service.name` | `OTEL_SERVICE_NAME` if set, otherwise `pcb-lens`. |
+| `service.version` | The running server version. |
+| `enduser.id` | The host OS account name of whoever is running the server. This attributes usage to the per-session user without any configuration. (Omitted if the username cannot be read.) |
+
+Add your own resource attributes with `OTEL_RESOURCE_ATTRIBUTES` (see below).
+
+## Configuration
+
+Telemetry is configured **purely through the standard OpenTelemetry environment variables** — there is no bespoke config file or API. Setting any OTLP endpoint turns it on.
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint for all signals. **Setting this (or any per-signal endpoint below) enables telemetry.** |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal endpoint override for traces. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Per-signal endpoint override for metrics. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Per-signal endpoint override for logs. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers sent with every export, e.g. `Authorization=Bearer <token>` for a managed backend. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is **not** bundled in the standalone binaries and falls back to `http/protobuf` with a warning on stderr. |
+| `OTEL_SERVICE_NAME` | Service identity in the `service.name` resource attribute. Defaults to `pcb-lens`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes, e.g. `deployment.environment=prod,team=hw`. |
+| `OTEL_TRACES_SAMPLER` | Standard OTel trace sampler selection. |
+| `OTEL_BSP_SCHEDULE_DELAY` | Batch span processor export interval (ms). |
+| `OTEL_BLRP_SCHEDULE_DELAY` | Batch log record processor export interval (ms). |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval in ms (default `60000`). |
+| `OTEL_SDK_DISABLED` | Set to `true`/`1` to force telemetry off even if an endpoint is configured. |
+
+Application-specific option:
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments as the `tool.args` span attribute. Off by default — arguments (file paths, net names) may be sensitive. |
+
+> **Protocol note:** Because the server ships as a standalone compiled binary, only the HTTP OTLP exporters are bundled. Use `http/protobuf` (the default, port `4318` on most collectors) or `http/json`. If you point at a gRPC-only endpoint (`4317`), switch the backend to accept OTLP/HTTP instead.
+
+## Integration guides
+
+### Local Collector / Jaeger quick start
+
+Run an all-in-one Jaeger (which accepts OTLP and renders traces) and point the server at it:
+
+```bash
+docker run --rm -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
+
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_SERVICE_NAME=pcb-lens
+# then start the MCP server as usual; open http://localhost:16686 to view traces
+```
+
+Invoke a tool through your AI client, then look for `tool/<tool_name>` spans under the `pcb-lens` service in the Jaeger UI.
+
+### Managed / cloud backend
+
+Most hosted backends accept OTLP/HTTP with an auth header. Point at their ingest endpoint and pass credentials via `OTEL_EXPORTER_OTLP_HEADERS`:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example-vendor.com
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${VENDOR_API_KEY}"
+export OTEL_SERVICE_NAME=pcb-lens
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod
+```
+
+Multiple headers are comma-separated (`key1=value1,key2=value2`). Check your vendor's docs for the exact endpoint and header names (some use `api-key=...` rather than `Authorization`).
+
+### Setting the env vars per MCP client
+
+The server normally runs as a subprocess of your AI client, so set the `OTEL_*` variables in that client's MCP server config rather than your shell. For example, in a Claude Desktop / Claude Code style `mcpServers` entry:
+
+```json
+{
+  "mcpServers": {
+    "pcb-lens": {
+      "command": "pcb-lens",
+      "env": {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+        "OTEL_SERVICE_NAME": "pcb-lens"
+      }
+    }
+  }
+}
+```
+
+Any of the variables in the [Configuration](#configuration) table can be supplied this way.
+
+## Verifying it works
+
+1. With an endpoint configured, call any tool from your AI client.
+2. Confirm spans appear in your backend (e.g. the Jaeger UI at `http://localhost:16686`, service `pcb-lens`, operation `tool/<tool_name>`).
+3. Check `tool.calls` / `tool.duration` metrics and the correlated log records.
+
+If nothing arrives, the server itself keeps working — telemetry failures are silent on the hot path. Look at the server's **stderr** for `[otel]` diagnostic lines (e.g. an init failure or a gRPC fallback warning), and double-check the endpoint, protocol (`http/protobuf` vs `http/json`), and port (`4318` for OTLP/HTTP).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ A span named `tool/<tool_name>` (for example, `tool/get_pcb_metadata`) is create
 | `error.type` | string | Present only on failure. The error name (e.g. `Error`), or `tool_error` when the tool returned a structured error result. |
 | `tool.args` | string | JSON-serialized tool arguments. **Only recorded when `OTEL_CAPTURE_TOOL_ARGS` is `1` or `true`** (off by default; arguments may be sensitive). |
 
-The span status is set to `ERROR` on failure (and the exception is recorded), `OK` otherwise.
+The span status is set to `ERROR` on failure, `OK` otherwise. A thrown exception is recorded on the span; a structured tool-error result sets `error.type` to `tool_error` without attaching an exception.
 
 ### Metrics
 
@@ -79,13 +79,14 @@ Telemetry is configured **purely through the standard OpenTelemetry environment 
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is **not** bundled in the standalone binaries and falls back to `http/protobuf` with a warning on stderr. |
 | `OTEL_SERVICE_NAME` | Service identity in the `service.name` resource attribute. Defaults to `pcb-lens`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes, e.g. `deployment.environment=prod,team=hw`. |
-| `OTEL_TRACES_SAMPLER` | Standard OTel trace sampler selection. |
+| `OTEL_TRACES_SAMPLER` | Standard OTel trace sampler selection (e.g. `traceidratio`). |
+| `OTEL_TRACES_SAMPLER_ARG` | Argument for the sampler, e.g. `0.1` for `traceidratio`. Used together with `OTEL_TRACES_SAMPLER`. |
 | `OTEL_BSP_SCHEDULE_DELAY` | Batch span processor export interval (ms). |
 | `OTEL_BLRP_SCHEDULE_DELAY` | Batch log record processor export interval (ms). |
 | `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval in ms (default `60000`). |
 | `OTEL_SDK_DISABLED` | Set to `true`/`1` to force telemetry off even if an endpoint is configured. |
 
-The sampler and batch/interval knobs (`OTEL_TRACES_SAMPLER`, `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`) are standard OpenTelemetry variables read directly by the SDK, so you won't find them referenced in this project's code.
+The sampler and batch/interval knobs (`OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG`, `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`) are standard OpenTelemetry variables read directly by the SDK, so you won't find them referenced in this project's code.
 
 Application-specific option:
 
@@ -93,7 +94,7 @@ Application-specific option:
 |----------|---------|
 | `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments as the `tool.args` span attribute. Off by default — arguments (file paths, net names) may be sensitive. |
 
-> **Protocol note:** Because the server ships as a standalone compiled binary, only the HTTP OTLP exporters are bundled. Use `http/protobuf` (the default) or `http/json`, both on the OTLP/HTTP port (`4318` on most collectors). If you point at a gRPC-only endpoint (`4317`), switch the backend to accept OTLP/HTTP instead.
+> **Protocol note:** Because the server ships as a standalone compiled binary, only the HTTP OTLP exporters are bundled. Use `http/protobuf` (the default) or `http/json`, both on the OTLP/HTTP port (`4318` on most collectors). Collectors typically listen on `4317` for gRPC and `4318` for HTTP; if you point at a gRPC endpoint, switch the backend to accept OTLP/HTTP instead.
 
 ## Integration guides
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,7 +25,7 @@ A span named `tool/<tool_name>` (for example, `tool/get_pcb_metadata`) is create
 | `tool.outcome` | string | `success` or `error`. |
 | `tool.duration_ms` | number | Wall-clock duration of the tool call in milliseconds. |
 | `error.type` | string | Present only on failure. The error name (e.g. `Error`), or `tool_error` when the tool returned a structured error result. |
-| `tool.args` | string | JSON-serialized tool arguments. **Only recorded when `OTEL_CAPTURE_TOOL_ARGS=1`** (off by default; arguments may be sensitive). |
+| `tool.args` | string | JSON-serialized tool arguments. **Only recorded when `OTEL_CAPTURE_TOOL_ARGS` is `1` or `true`** (off by default; arguments may be sensitive). |
 
 The span status is set to `ERROR` on failure (and the exception is recorded), `OK` otherwise.
 
@@ -61,6 +61,8 @@ These apply to every span, metric, and log record:
 | `service.version` | The running server version. |
 | `enduser.id` | The host OS account name of whoever is running the server. This attributes usage to the per-session user without any configuration. (Omitted if the username cannot be read.) |
 
+> **Privacy note:** `enduser.id` carries the host OS username and is sent to whatever OTLP backend you configure — appearing on every trace, metric, and log. If that backend is a third-party or managed cloud service, confirm this is acceptable under your data policy before enabling telemetry. To collect no telemetry at all, leave the endpoint unset (or set `OTEL_SDK_DISABLED=true`).
+
 Add your own resource attributes with `OTEL_RESOURCE_ATTRIBUTES` (see below).
 
 ## Configuration
@@ -89,7 +91,7 @@ Application-specific option:
 |----------|---------|
 | `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments as the `tool.args` span attribute. Off by default — arguments (file paths, net names) may be sensitive. |
 
-> **Protocol note:** Because the server ships as a standalone compiled binary, only the HTTP OTLP exporters are bundled. Use `http/protobuf` (the default, port `4318` on most collectors) or `http/json`. If you point at a gRPC-only endpoint (`4317`), switch the backend to accept OTLP/HTTP instead.
+> **Protocol note:** Because the server ships as a standalone compiled binary, only the HTTP OTLP exporters are bundled. Use `http/protobuf` (the default) or `http/json`, both on the OTLP/HTTP port (`4318` on most collectors). If you point at a gRPC-only endpoint (`4317`), switch the backend to accept OTLP/HTTP instead.
 
 ## Integration guides
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,7 +6,7 @@ This is the full developer reference and integration guide. For a one-paragraph 
 
 ## Design guarantees
 
-- **Disabled by default, zero overhead.** If no OTLP endpoint is configured, the SDK is never imported and instrumentation is a pure pass-through. Enabling telemetry requires no code changes — only standard `OTEL_*` environment variables.
+- **Disabled by default, zero overhead.** If no OTLP endpoint is configured, the SDK is never imported and instrumentation is a pure pass-through. Enabling telemetry requires no code changes — only standard `OTEL_*` environment variables. Before enabling it against a third-party backend, note the [privacy note](#resource-attributes) on `enduser.id`.
 - **Telemetry never breaks a tool call.** Every span, metric, and log operation is wrapped so that an exporter fault, misconfiguration, or unreachable backend degrades to "no telemetry" — it never surfaces an error to the caller or changes a tool result.
 - **stdout is reserved for MCP.** The server speaks JSON-RPC over stdio, so stdout carries the MCP protocol. All telemetry diagnostics go to **stderr only**, and no console/stdout exporter is ever used.
 - **Flushed on shutdown.** Batched, asynchronous exports are flushed when the process exits (including `SIGINT`/`SIGTERM`), so short-lived invocations do not lose data.
@@ -85,6 +85,8 @@ Telemetry is configured **purely through the standard OpenTelemetry environment 
 | `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval in ms (default `60000`). |
 | `OTEL_SDK_DISABLED` | Set to `true`/`1` to force telemetry off even if an endpoint is configured. |
 
+The sampler and batch/interval knobs (`OTEL_TRACES_SAMPLER`, `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`) are standard OpenTelemetry variables read directly by the SDK, so you won't find them referenced in this project's code.
+
 Application-specific option:
 
 | Variable | Purpose |
@@ -146,6 +148,6 @@ Any of the variables in the [Configuration](#configuration) table can be supplie
 
 1. With an endpoint configured, call any tool from your AI client.
 2. Confirm spans appear in your backend (e.g. the Jaeger UI at `http://localhost:16686`, service `pcb-lens`, operation `tool/<tool_name>`).
-3. Check `tool.calls` / `tool.duration` metrics and the correlated log records.
+3. Check `tool.calls` / `tool.duration` metrics and the correlated log records. (Metrics and logs need a metrics/logs-capable backend such as an OpenTelemetry Collector, Prometheus, or Grafana — Jaeger renders traces only.)
 
 If nothing arrives, the server itself keeps working — telemetry failures are silent on the hot path. Look at the server's **stderr** for `[otel]` diagnostic lines (e.g. an init failure or a gRPC fallback warning), and double-check the endpoint, protocol (`http/protobuf` vs `http/json`), and port (`4318` for OTLP/HTTP).


### PR DESCRIPTION
## What & why

The server already exposes a full, vendor-neutral **OpenTelemetry** integration (`src/telemetry/otel.ts`), but it was documented **only in the root README**. `docs/` — our home for full developer specs — had nothing on telemetry. A developer wanting to wire the server into their own Otel backend had to read summary prose rather than a proper reference.

This adds a first-class OpenTelemetry developer reference + integration guide under `docs/`, and trims the README down to a summary that defers to it.

## Changes

- **`docs/observability.md` (new)** — the full developer reference:
  - Design guarantees (disabled-by-default zero overhead, never breaks a tool call, stderr-only diagnostics, flushed on shutdown).
  - Signal reference: span `tool/<tool_name>` attributes, the `tool.calls`/`tool.duration`/`tool.errors` metric instruments, log records, and resource attributes (`service.name`, `service.version`, `enduser.id`).
  - Complete `OTEL_*` configuration table (general + per-signal endpoints, headers, protocol, sampler, batch/interval knobs, `OTEL_SDK_DISABLED`) plus the app-specific `OTEL_CAPTURE_TOOL_ARGS`.
  - Integration recipes: local Collector/Jaeger, managed backend auth via `OTEL_EXPORTER_OTLP_HEADERS`, and per-MCP-client `env` config.
  - Verification + troubleshooting (stderr `[otel]` diagnostics, `http/protobuf` vs `http/json`, port `4318`).
- **`docs/README.md`** — adds an Observability section linking the new guide.
- **`README.md`** — replaces the long Observability section with a short summary that defers to `docs/observability.md`.

All documented behavior was cross-checked against `src/telemetry/otel.ts`. Scope is OpenTelemetry only; the internal local JSONL analytics is intentionally not covered. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tE1pnpX7BpMSzwQv98Pjs

---
_Generated by [Claude Code](https://claude.ai/code/session_014tE1pnpX7BpMSzwQv98Pjs)_