### PR TITLE
ci: enable manual workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Small change to allow running CI manually (`workflow_dispatch`). Primary purpose
is to validate that Actions run green end-to-end on a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)