### PR TITLE
Release v1.1.0: per-trace routing geometry export + accurate conductor widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-23
+
+### Added
+
+- `get_pcb_net` with `detail="full"` now returns a `segments` array of per-trace centerline routing geometry alongside the existing per-via coordinates. Each entry is one `<Polyline>`/`<Line>` conductor primitive: `{ layer, width, points }` (vertices in microns), plus `arcs` carrying full `<PolyStepCurve>` curvature (`index`, `centerX`, `centerY`, `clockwise`) when the trace is curved. The array is stratified across layers and capped at `MAX_COORD_ROWS = 300` with `truncated: true` when sampled; the per-layer `routing` rollup still reports the true Set-level totals. `detail="full"` must be set explicitly — `summary` (the default) output is unchanged and emits no `segments`. Poured `<Contour>` copper has no centerline and is excluded from `segments`; the rollup still reports it routed. `segments.length` is per-primitive and intentionally differs from `totalSegments` / `routing[].segmentCount`, which are Set-level (#55)
+
+### Changed
+
+- `get_pcb_net` reports each trace's own width from its `<LineDescRef>`/`<LineDesc>` rather than a single set-level value, so two `<Line>` (or `<Polyline>`) conductors of differing width inside one `<Set>` keep their distinct widths instead of collapsing to the last descriptor seen; a primitive falls back to the set/feature-level width only when it carries none of its own. The summary `routing[].traceWidths` rollup is tightened the same way and now lists every distinct conductor width a `<Set>` uses. `<PolyStepCurve>` (curved) vertices, previously dropped, are now parsed for the geometry export (#55)
+
 ## [1.0.4] - 2026-06-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/pcb-lens",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "MCP server for IPC-2581 PCB layout analysis and review",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/export-cadence-constraints.ts
+++ b/src/tools/export-cadence-constraints.ts
@@ -95,7 +95,7 @@ export const register = (server: McpServer): void => {
     "export_cadence_constraints",
     {
       description:
-        "Export a Cadence Allegro .brd file to .tcfx constraint XML. Windows only. Requires Cadence SPB installation (auto-detected). Calls are serialized internally to avoid license conflicts.",
+        "Export the design rules and constraints from a Cadence Allegro .brd file to a .tcfx file, which you can then read with get_constraints. Windows only, and requires a Cadence SPB installation (detected automatically).",
       inputSchema: {
         board: z.string().describe("Path to Cadence Allegro .brd file"),
         output: z

--- a/src/tools/export-cadence-ipc2581.ts
+++ b/src/tools/export-cadence-ipc2581.ts
@@ -109,7 +109,7 @@ export const register = (server: McpServer): void => {
     "export_cadence_ipc2581",
     {
       description:
-        "Export a Cadence Allegro .brd file to IPC-2581 XML. Windows only. Requires Cadence SPB installation (auto-detected). Calls are serialized internally to avoid license conflicts.",
+        "Export a Cadence Allegro .brd file to an IPC-2581 XML file, the format the other PCB query tools (get_pcb_metadata, get_pcb_component, get_pcb_net) read. Windows only, and requires a Cadence SPB installation (detected automatically).",
       inputSchema: {
         board: z.string().describe("Path to Cadence Allegro .brd file"),
         output: z
@@ -121,7 +121,9 @@ export const register = (server: McpServer): void => {
         revision: z
           .enum(["B", "C"])
           .optional()
-          .describe('IPC-2581 revision: "B" (1.03) or "C" (1.04, default). Rev C is richest.'),
+          .describe(
+            'IPC-2581 revision to write: "B" (1.03) or "C" (1.04, the default). Rev C carries the most layout detail; prefer it unless a downstream tool needs Rev B.'
+          ),
       },
     },
     withTelemetry("export_cadence_ipc2581", async ({ board, output, revision }) => {

--- a/src/tools/get-pcb-component.ts
+++ b/src/tools/get-pcb-component.ts
@@ -309,7 +309,7 @@ export const register = (server: McpServer): void => {
     "get_pcb_component",
     {
       description:
-        "Look up a single component by exact refdes in an IPC-2581 file. Returns placement, package, BOM data, connected nets with pin names, and a pad-geometry summary (pad count + deduped pad shapes). Pass detail='full' for per-pin pad coordinates (capped).",
+        "Look up a single component by its exact reference designator (refdes). Returns its placement (position, rotation, layer), package and BOM details, the nets connected to each pin, and a summary of its pads (count and the distinct pad shapes). The refdes must match exactly; it is not a pattern. Set detail='full' to additionally get the exact coordinate of every pad (sampled for components with very many pads).",
       inputSchema: {
         file: z.string().describe("Path to IPC-2581 XML file"),
         refdes: z
@@ -319,7 +319,7 @@ export const register = (server: McpServer): void => {
           .enum(["summary", "full"])
           .default("summary")
           .describe(
-            "Response detail. 'summary' (default) returns pad count + shapes only; 'full' adds per-pin pad x/y coordinates (capped to stay within the response budget)."
+            "How much to return. 'summary' (default) gives the pad count and distinct pad shapes. 'full' additionally returns the exact coordinate of each pad; components with very many pads are sampled. Use 'full' only when you need exact pad positions, since responses are larger."
           ),
       },
     },

--- a/src/tools/get-pcb-metadata.ts
+++ b/src/tools/get-pcb-metadata.ts
@@ -116,7 +116,7 @@ export const register = (server: McpServer): void => {
     "get_pcb_metadata",
     {
       description:
-        "Get an overview of an IPC-2581 PCB design file: metadata, layer stackup, component/net counts, and section sizes",
+        "Get a high-level overview of a PCB design file: file metadata, the layer stackup, design units, and the total component and net counts. Use this first to understand a design's size and layers before querying specific components or nets.",
       inputSchema: {
         file: z.string().describe("Path to IPC-2581 XML file"),
       },

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -551,6 +551,7 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
   <LogicalNet name="OVERRIDE1"><PinRef pin="1" componentRef="U4"/></LogicalNet>
   <LogicalNet name="POURSEG"><PinRef pin="1" componentRef="U5"/></LogicalNet>
   <LogicalNet name="MULTILINE"><PinRef pin="1" componentRef="U6"/></LogicalNet>
+  <LogicalNet name="MIXFALLBACK"><PinRef pin="1" componentRef="U7"/></LogicalNet>
   <Step>
     <PhyNetGroup/>
     <LayerFeature layerRef="TOP">
@@ -558,6 +559,20 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
         <Features>
           <Line startX="0" startY="0" endX="1" endY="0"><LineDescRef id="LD_A"/></Line>
           <Line startX="1" startY="0" endX="2" endY="0"><LineDescRef id="LD_B"/></Line>
+        </Features>
+      </Set>
+      <Set net="MIXFALLBACK">
+        <LineDescRef id="LDS"/>
+        <Features>
+          <Polyline>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="1" y="0"/>
+            <LineDescRef id="LD_B"/>
+          </Polyline>
+          <Polyline>
+            <PolyBegin x="2" y="0"/>
+            <PolyStepSegment x="3" y="0"/>
+          </Polyline>
         </Features>
       </Set>
       <Set net="POLY1">
@@ -672,6 +687,18 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
     const byEnd = Object.fromEntries(net.segments!.map((s) => [s.points[1][0], s.width]));
     expect(byEnd[1000]).toBe(100); // first line -> LD_A 0.10mm
     expect(byEnd[2000]).toBe(200); // second line -> LD_B 0.20mm
+  });
+
+  it("falls back to the true set-level width, not a sibling primitive's, for a bare trace (detail=full)", async () => {
+    // One <Set>: a set-level <LineDescRef> (LDS=0.15), then a Polyline with its
+    // own descriptor (LD_B=0.20), then a Polyline with none. The bare Polyline
+    // must fall back to the set-level 0.15mm -- NOT to 0.20mm leaked from the
+    // first Polyline's descriptor (the currentSetLineDescId overwrite bug).
+    const net = expectSuccess(await queryNet(segXml, "^MIXFALLBACK$", "full")).matches[0];
+    expect(net.segments).toHaveLength(2);
+    const byEnd = Object.fromEntries(net.segments!.map((s) => [s.points[1][0], s.width]));
+    expect(byEnd[1000]).toBe(200); // first polyline -> own LD_B 0.20mm
+    expect(byEnd[3000]).toBe(150); // bare polyline -> set-level LDS 0.15mm fallback
   });
 
   it("rollup traceWidths reports every width a multi-primitive <Set> uses (summary)", async () => {

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -552,6 +552,8 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
   <LogicalNet name="POURSEG"><PinRef pin="1" componentRef="U5"/></LogicalNet>
   <LogicalNet name="MULTILINE"><PinRef pin="1" componentRef="U6"/></LogicalNet>
   <LogicalNet name="MIXFALLBACK"><PinRef pin="1" componentRef="U7"/></LogicalNet>
+  <LogicalNet name="PADPOLY"><PinRef pin="1" componentRef="U8"/></LogicalNet>
+  <LogicalNet name="LAYERLESS"><PinRef pin="1" componentRef="U9"/></LogicalNet>
   <Step>
     <PhyNetGroup/>
     <LayerFeature layerRef="TOP">
@@ -619,6 +621,29 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
               <PolyStepSegment x="0" y="0"/>
             </Polygon>
           </Contour>
+        </Features>
+      </Set>
+      <Set net="PADPOLY">
+        <Pad padstackDefRef="PS1">
+          <Location x="5" y="5"/>
+          <Polyline>
+            <PolyBegin x="5" y="5"/>
+            <PolyStepSegment x="6" y="5"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
+          <Line startX="6" startY="5" endX="7" endY="5"><LineDescRef id="LD_B"/></Line>
+          <PinRef pin="1" componentRef="U8"/>
+        </Pad>
+      </Set>
+    </LayerFeature>
+    <LayerFeature id="NO_LAYERREF">
+      <Set net="LAYERLESS">
+        <Features>
+          <Polyline>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="1" y="0"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
         </Features>
       </Set>
     </LayerFeature>
@@ -721,6 +746,26 @@ describe("queryNet -- per-trace routing geometry (detail=full)", () => {
     const net = expectSuccess(await queryNet(segXml, "^POURSEG$", "full")).matches[0];
     // Routed (rollup present) but no centerline geometry to export.
     expect(net.routing!.find((rt) => rt.layerName === "TOP")!.segmentCount).toBe(1);
+    expect(net).not.toHaveProperty("segments");
+  });
+
+  it("ignores a <Polyline>/<Line> inside a <Pad> (not routing, not a segment)", async () => {
+    // A custom pad outline drawn as a <Polyline>/<Line> inside <Pad> must not
+    // make the net look routed nor leak into segments -- same inPad guard the
+    // <Contour> path already has. No real fixture carries this (pad outlines are
+    // normally <Contour>/<Polygon>), so it is exercised with inline XML.
+    const net = expectSuccess(await queryNet(segXml, "^PADPOLY$", "full")).matches[0];
+    expect(net.pins.U8).toEqual(["1"]); // the pin still connects
+    expect(net).not.toHaveProperty("routing"); // pad geometry is not routing
+    expect(net).not.toHaveProperty("segments");
+  });
+
+  it("drops segments from a layer-less <LayerFeature> (no layerRef)", async () => {
+    // A <LayerFeature> with no layerRef would otherwise emit layer-"" segments;
+    // the flush is gated on currentLayerName for symmetry with the rollup, which
+    // already drops such a Set. No real fixture omits layerRef, so inline XML.
+    const net = expectSuccess(await queryNet(segXml, "^LAYERLESS$", "full")).matches[0];
+    expect(net).not.toHaveProperty("routing");
     expect(net).not.toHaveProperty("segments");
   });
 

--- a/src/tools/get-pcb-net.test.ts
+++ b/src/tools/get-pcb-net.test.ts
@@ -14,6 +14,8 @@ const TESTCASE1_REVC = path.join(FIXTURE_DIR, "testcase1-RevC.xml");
 const hasTestcase1Fixture = existsSync(TESTCASE1_REVC);
 const PARALLELLA_REVB = path.join(FIXTURE_DIR, "parallella-RevB.xml");
 const hasParallellaFixture = existsSync(PARALLELLA_REVB);
+const TESTCASE3_REVC = path.join(FIXTURE_DIR, "testcase3-RevC.xml");
+const hasTestcase3Fixture = existsSync(TESTCASE3_REVC);
 
 // ---------------------------------------------------------------------------
 // Inline fixture -- covers LogicalNet pins, PhyNetPoint layers, LayerFeature
@@ -369,6 +371,31 @@ describe.skipIf(!hasTestcase1Fixture)("queryNet -- <Line> routing on testcase1 R
     // TOP previously reported 3 segments (polylines only); <Line> segments add more.
     expect(top!.segmentCount).toBeGreaterThan(3);
   });
+
+  it("returns per-trace segments consistent with the routing rollup (detail=full)", async () => {
+    const summary = expectSuccess(await queryNet(TESTCASE1_REVC, "^UN21RES96PA0$")).matches[0];
+    expect(summary).not.toHaveProperty("segments"); // opt-in only
+
+    const net = expectSuccess(await queryNet(TESTCASE1_REVC, "^UN21RES96PA0$", "full")).matches[0];
+    expect(net.segments).toBeDefined();
+    expect(net.segments!.length).toBeGreaterThan(0);
+
+    const routingLayers = new Set(net.routing!.map((rt) => rt.layerName));
+    for (const seg of net.segments!) {
+      expect(routingLayers.has(seg.layer)).toBe(true); // no phantom layers
+      expect(seg.points.length).toBeGreaterThanOrEqual(2); // real geometry
+      expect(seg.width).toBeGreaterThanOrEqual(0);
+    }
+    // Every centerline width the rollup reports for a layer should be realizable
+    // by some trace on that layer (the rollup is derived from the same widths).
+    const top = net.routing!.find((rt) => rt.layerName === "TOP")!;
+    const topSegWidths = new Set(
+      net.segments!.filter((s) => s.layer === "TOP").map((s) => s.width)
+    );
+    for (const w of top.traceWidths) {
+      expect(topSegWidths.has(w)).toBe(true);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -497,6 +524,262 @@ describe.skipIf(!hasParallellaFixture)("queryNet -- poured copper on parallella 
     expect(net.routing).toBeDefined();
     expect(net.routing!.length).toBeGreaterThan(0);
     expect(net.routing!.some((rt) => rt.segmentCount > 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-trace centerline routing geometry (detail="full"). Each <Polyline>/<Line>
+// conductor is returned as vertices + width + arcs. Opt-in only: summary mode
+// never emits it. Poured <Contour> shapes have no centerline and are excluded.
+// ---------------------------------------------------------------------------
+describe("queryNet -- per-trace routing geometry (detail=full)", () => {
+  // POLY1: 3-vertex polyline, width via set-level <LineDescRef>.
+  // ARC1:  polyline with a <PolyStepCurve> (curved vertex).
+  // LINE1: single <Line> (3-4-5).
+  // OVERRIDE1: polyline-local <LineDesc> overrides the set-level <LineDescRef>.
+  // POURSEG: poured <Contour> (no centerline -> excluded from segments).
+  const SEG_XML = `<IPC-2581>
+  <Content>
+    <EntryLineDesc id="LDS"><LineDesc lineWidth="0.15"/></EntryLineDesc>
+    <EntryLineDesc id="LD_A"><LineDesc lineWidth="0.10"/></EntryLineDesc>
+    <EntryLineDesc id="LD_B"><LineDesc lineWidth="0.20"/></EntryLineDesc>
+  </Content>
+  <CadHeader units="MILLIMETER"/>
+  <LogicalNet name="POLY1"><PinRef pin="1" componentRef="U1"/></LogicalNet>
+  <LogicalNet name="ARC1"><PinRef pin="1" componentRef="U2"/></LogicalNet>
+  <LogicalNet name="LINE1"><PinRef pin="1" componentRef="U3"/></LogicalNet>
+  <LogicalNet name="OVERRIDE1"><PinRef pin="1" componentRef="U4"/></LogicalNet>
+  <LogicalNet name="POURSEG"><PinRef pin="1" componentRef="U5"/></LogicalNet>
+  <LogicalNet name="MULTILINE"><PinRef pin="1" componentRef="U6"/></LogicalNet>
+  <Step>
+    <PhyNetGroup/>
+    <LayerFeature layerRef="TOP">
+      <Set net="MULTILINE">
+        <Features>
+          <Line startX="0" startY="0" endX="1" endY="0"><LineDescRef id="LD_A"/></Line>
+          <Line startX="1" startY="0" endX="2" endY="0"><LineDescRef id="LD_B"/></Line>
+        </Features>
+      </Set>
+      <Set net="POLY1">
+        <Features>
+          <Polyline>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="1" y="0"/>
+            <PolyStepSegment x="1" y="2"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
+        </Features>
+      </Set>
+      <Set net="ARC1">
+        <Features>
+          <Polyline>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepCurve x="2" y="2" centerX="2" centerY="0" clockwise="true"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
+        </Features>
+      </Set>
+      <Set net="LINE1">
+        <Features>
+          <Line startX="0" startY="0" endX="3" endY="4"><LineDescRef id="LDS"/></Line>
+        </Features>
+      </Set>
+      <Set net="OVERRIDE1">
+        <Features>
+          <Polyline>
+            <PolyBegin x="0" y="0"/>
+            <PolyStepSegment x="1" y="0"/>
+            <LineDesc lineWidth="0.40"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
+        </Features>
+      </Set>
+      <Set net="POURSEG">
+        <Features>
+          <Contour>
+            <Polygon>
+              <PolyBegin x="0" y="0"/>
+              <PolyStepSegment x="1" y="0"/>
+              <PolyStepSegment x="1" y="1"/>
+              <PolyStepSegment x="0" y="0"/>
+            </Polygon>
+          </Contour>
+        </Features>
+      </Set>
+    </LayerFeature>
+  </Step>
+</IPC-2581>`;
+
+  let segXml: string;
+  beforeAll(() => {
+    segXml = path.join(tempDir, "segments.xml");
+    writeFileSync(segXml, SEG_XML);
+  });
+
+  it("omits segments in summary mode (and by default)", async () => {
+    const summary = expectSuccess(await queryNet(segXml, "^POLY1$")).matches[0];
+    expect(summary).not.toHaveProperty("segments");
+    // Default detail is summary: the explicit and implicit calls agree.
+    const def = expectSuccess(await queryNet(segXml, "^POLY1$", "summary")).matches[0];
+    expect(def).not.toHaveProperty("segments");
+    // The per-layer rollup is unaffected.
+    expect(summary.routing!.find((rt) => rt.layerName === "TOP")!.segmentCount).toBe(1);
+  });
+
+  it("returns a polyline trace with vertices and set-level width (detail=full)", async () => {
+    const net = expectSuccess(await queryNet(segXml, "^POLY1$", "full")).matches[0];
+    expect(net.segments).toBeDefined();
+    expect(net.segments).toHaveLength(1);
+    const seg = net.segments![0];
+    expect(seg.layer).toBe("TOP");
+    expect(seg.width).toBe(150); // 0.15mm -> 150 micron
+    expect(seg.points).toEqual([
+      [0, 0],
+      [1000, 0],
+      [1000, 2000],
+    ]);
+    expect(seg).not.toHaveProperty("arcs"); // no curved vertices
+  });
+
+  it("returns a single <Line> as a 2-point trace (detail=full)", async () => {
+    const net = expectSuccess(await queryNet(segXml, "^LINE1$", "full")).matches[0];
+    expect(net.segments).toHaveLength(1);
+    const seg = net.segments![0];
+    expect(seg.points).toEqual([
+      [0, 0],
+      [3000, 4000],
+    ]);
+    expect(seg.width).toBe(150);
+  });
+
+  it("captures full arc geometry from <PolyStepCurve> (detail=full)", async () => {
+    const net = expectSuccess(await queryNet(segXml, "^ARC1$", "full")).matches[0];
+    const seg = net.segments![0];
+    expect(seg.points).toEqual([
+      [0, 0],
+      [2000, 2000],
+    ]);
+    expect(seg.arcs).toEqual([{ index: 1, centerX: 2000, centerY: 0, clockwise: true }]);
+  });
+
+  it("reports each <Line>'s own width when one <Set> holds several (detail=full)", async () => {
+    // Two lines, one Set, distinct LineDescRefs (0.10mm and 0.20mm). The widths
+    // must reflect each line's own descriptor -- not a single set-level value
+    // applied to both.
+    const net = expectSuccess(await queryNet(segXml, "^MULTILINE$", "full")).matches[0];
+    expect(net.segments).toHaveLength(2);
+    // points preserve order, so widths line up with the source lines.
+    const byEnd = Object.fromEntries(net.segments!.map((s) => [s.points[1][0], s.width]));
+    expect(byEnd[1000]).toBe(100); // first line -> LD_A 0.10mm
+    expect(byEnd[2000]).toBe(200); // second line -> LD_B 0.20mm
+  });
+
+  it("rollup traceWidths reports every width a multi-primitive <Set> uses (summary)", async () => {
+    // Same MULTILINE net in summary mode: the per-layer rollup must list BOTH
+    // conductor widths, not just the last descriptor's. This is the aggregate
+    // counterpart to the per-trace check above and works without detail=full.
+    const net = expectSuccess(await queryNet(segXml, "^MULTILINE$")).matches[0];
+    expect(net).not.toHaveProperty("segments"); // still summary
+    const top = net.routing!.find((rt) => rt.layerName === "TOP")!;
+    expect(top.traceWidths).toEqual([100, 200]); // sorted, both present
+  });
+
+  it("lets a polyline-local <LineDesc> override the set-level width (detail=full)", async () => {
+    const net = expectSuccess(await queryNet(segXml, "^OVERRIDE1$", "full")).matches[0];
+    // Polyline-local 0.40mm wins over the set-level LDS (0.15mm).
+    expect(net.segments![0].width).toBe(400);
+  });
+
+  it("excludes poured <Contour> copper from segments but still reports the rollup", async () => {
+    const net = expectSuccess(await queryNet(segXml, "^POURSEG$", "full")).matches[0];
+    // Routed (rollup present) but no centerline geometry to export.
+    expect(net.routing!.find((rt) => rt.layerName === "TOP")!.segmentCount).toBe(1);
+    expect(net).not.toHaveProperty("segments");
+  });
+
+  it("keeps each matched net's segments independent", async () => {
+    const r = expectSuccess(await queryNet(segXml, "^(POLY1|ARC1)$", "full"));
+    // Matches are sorted alphabetically: ARC1, then POLY1.
+    expect(r.matches.map((m) => m.netName)).toEqual(["ARC1", "POLY1"]);
+    expect(r.matches[0].segments![0].arcs).toBeDefined(); // ARC1 has the curve
+    expect(r.matches[1].segments![0]).not.toHaveProperty("arcs"); // POLY1 does not
+    expect(r.matches[1].segments![0].points).toHaveLength(3);
+  });
+
+  it("caps segments at the budget, flags truncated, and keeps the rollup exact", async () => {
+    const onTop = MAX_COORD_ROWS - 50; // 250
+    const onBottom = 150; // total 400 > MAX_COORD_ROWS
+    const traceSet = (i: number) =>
+      `      <Set net="MANY">
+        <Features>
+          <Polyline>
+            <PolyBegin x="${i}" y="0"/>
+            <PolyStepSegment x="${i}" y="1"/>
+            <LineDescRef id="LDS"/>
+          </Polyline>
+        </Features>
+      </Set>`;
+    const topSets = Array.from({ length: onTop }, (_, i) => traceSet(i)).join("\n");
+    const botSets = Array.from({ length: onBottom }, (_, i) => traceSet(i)).join("\n");
+    const xml = `<IPC-2581>
+  <Content>
+    <EntryLineDesc id="LDS"><LineDesc lineWidth="0.15"/></EntryLineDesc>
+  </Content>
+  <CadHeader units="MILLIMETER"/>
+  <LogicalNet name="MANY"><PinRef pin="1" componentRef="U1"/></LogicalNet>
+  <Step>
+    <PhyNetGroup/>
+    <LayerFeature layerRef="TOP">
+${topSets}
+    </LayerFeature>
+    <LayerFeature layerRef="BOTTOM">
+${botSets}
+    </LayerFeature>
+  </Step>
+</IPC-2581>`;
+    const f = path.join(tempDir, "many-segments.xml");
+    writeFileSync(f, xml);
+
+    const net = expectSuccess(await queryNet(f, "^MANY$", "full")).matches[0];
+    expect(net.segments!.length).toBe(MAX_COORD_ROWS);
+    expect(net.truncated).toBe(true);
+    // Stratified by layer: both layers survive the cap.
+    const layers = new Set(net.segments!.map((s) => s.layer));
+    expect(layers).toEqual(new Set(["TOP", "BOTTOM"]));
+    // The Set-level rollup carries the true per-layer totals, unaffected by the cap.
+    expect(net.routing!.find((rt) => rt.layerName === "TOP")!.segmentCount).toBe(onTop);
+    expect(net.routing!.find((rt) => rt.layerName === "BOTTOM")!.segmentCount).toBe(onBottom);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-fixture arc regression. On testcase3 RevC the net UN1DAC71PDAC3 is routed
+// on layer IS2 with a <Polyline> that contains a <PolyStepCurve> (a curved
+// vertex). It has only a handful of conductor sets, so it stays under the cap and
+// its arc survives -- proving real arc geometry is captured (not just synthetic).
+// ---------------------------------------------------------------------------
+describe.skipIf(!hasTestcase3Fixture)("queryNet -- arc routing on testcase3 RevC", () => {
+  it("captures real <PolyStepCurve> arc geometry for UN1DAC71PDAC3 (detail=full)", async () => {
+    const summary = expectSuccess(await queryNet(TESTCASE3_REVC, "^UN1DAC71PDAC3$")).matches[0];
+    expect(summary).not.toHaveProperty("segments"); // opt-in only
+
+    const net = expectSuccess(await queryNet(TESTCASE3_REVC, "^UN1DAC71PDAC3$", "full")).matches[0];
+    expect(net.segments).toBeDefined();
+    expect(net.truncated).toBeFalsy(); // small net, nothing dropped
+
+    const arced = net.segments!.filter((s) => s.arcs && s.arcs.length > 0);
+    expect(arced.length).toBeGreaterThan(0);
+    for (const s of arced) {
+      expect(s.width).toBeGreaterThan(0);
+      for (const a of s.arcs!) {
+        // Each arc indexes a real terminal vertex and carries full curvature.
+        expect(a.index).toBeGreaterThanOrEqual(0);
+        expect(a.index).toBeLessThan(s.points.length);
+        expect(Number.isFinite(a.centerX)).toBe(true);
+        expect(Number.isFinite(a.centerY)).toBe(true);
+        expect(typeof a.clockwise).toBe("boolean");
+      }
+    }
   });
 });
 

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -369,9 +369,20 @@ export const queryNet = async (
         currentSetHasConductor = true;
       }
 
+      // A <LineDescRef>/<LineDesc> that is a child of a <Polyline>/<Line>
+      // describes only that primitive; the per-trace fallback width
+      // (currentSetLineDescId / currentSetInlineWidth, used at </Set> for a
+      // trace with no descriptor of its own) must come ONLY from a true
+      // set-level descriptor — a direct child of the <Set> with no primitive
+      // open. `<Line ...>` carries its descriptor on the same physical line, so
+      // a line containing `<Line ` is inside a primitive even after the line was
+      // already flushed (inLine reset). The width still feeds the rollup
+      // unconditionally (every conductor width the Set uses is reported there).
+      const insidePrimitive = inPolyline || inLine || line.includes("<Line ");
+
       if (line.includes("<LineDescRef ")) {
         const id = attr(line, "id");
-        currentSetLineDescId = id;
+        if (!insidePrimitive) currentSetLineDescId = id;
         // Record this conductor's width for the rollup. inPad guards against a
         // (rare) pad-level reference; the </Set> guard discards widths from any
         // Set that turns out to carry no conductor geometry.
@@ -384,7 +395,7 @@ export const queryNet = async (
       if (line.includes("<LineDesc ") && !line.includes("<EntryLineDesc ")) {
         const inlineWidth = numAttr(line, "lineWidth");
         if (inlineWidth !== undefined) {
-          currentSetInlineWidth = inlineWidth;
+          if (!insidePrimitive) currentSetInlineWidth = inlineWidth;
           if (!inPad) setConductorWidths.push(Math.round(inlineWidth * factor));
         }
       }

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -558,7 +558,7 @@ export const register = (server: McpServer): void => {
     "get_pcb_net",
     {
       description:
-        "Query nets by name pattern in an IPC-2581 file. Returns grouped connected pins, per-layer routing, and a compact via rollup (count per drill type). Routing is read from conductor-layer copper geometry in the export (Polyline/Line centerline traces and poured Contour shapes); trace widths and lengths are reported for centerline-routed copper and are absent for shape/plane-routed (poured) copper, which has no centerline. If the IPC-2581 export was generated without conductor/etch (cline) feature output, the file carries no conductor geometry and routing is empty even though pins, vias, and layersUsed still populate. Pass detail='full' for raw per-via coordinates and per-trace centerline geometry (each Polyline/Line as vertices + width + arcs), both capped. Poured shapes have no centerline and are absent from the per-trace geometry; segments[].length is per-primitive and does not equal totalSegments (Set-level). Rejects patterns that match all nets.",
+        "Look up nets in a PCB layout by name and inspect their connectivity and routing. Provide a net-name pattern (a regular expression); for each matching net you get the connected component pins (grouped by component), the layers the net uses, a per-layer routing summary (trace widths, number of routed segments, and total routed length), and a via summary (count per drill size). All distances are in microns. Copper that is filled as a pour or plane instead of drawn as a trace is reported as routed on its layer but without a width or length, so a net can be fully routed yet show no trace width. A net that returns pins but no routing was most likely exported without its routed-copper data. Use a specific pattern: one that matches every net in the design is rejected. Set detail='full' to additionally return exact geometry — every via coordinate and the full point-by-point shape of each routed trace (including arcs for curved traces); for very large nets this geometry is sampled and the response is marked truncated.",
       inputSchema: {
         file: z.string().describe("Path to IPC-2581 XML file"),
         pattern: z
@@ -568,7 +568,7 @@ export const register = (server: McpServer): void => {
           .enum(["summary", "full"])
           .default("summary")
           .describe(
-            "Response detail. 'summary' (default) returns via counts and the per-layer routing rollup only. 'full' (must be set explicitly) additionally returns raw per-via x/y coordinates and per-trace centerline geometry (segments[]: vertices, width, arcs), both capped to stay within the response budget."
+            "How much to return. 'summary' (default) gives the per-layer routing summary and via counts. 'full' additionally returns exact geometry: every via coordinate and the full shape of each routed trace (its vertices, width, and arc data for curved traces); large nets are sampled and the response is marked truncated. Use 'full' only when you need exact coordinates, since responses are larger."
           ),
       },
     },

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -241,7 +241,10 @@ export const queryNet = async (
         }
       }
 
-      if (line.includes("<Polyline")) {
+      // A <Polyline> inside a <Pad> is a custom pad outline, not routing (same
+      // reason the <Contour> handler is inPad-guarded); ignore it so it neither
+      // marks the net routed nor leaks into segments.
+      if (!inPad && line.includes("<Polyline")) {
         currentSetHasConductor = true;
         inPolyline = true;
         polyPoints = [];
@@ -310,8 +313,10 @@ export const queryNet = async (
       // a <Polyline>. Cadence uses these for single-segment traces; a net routed
       // entirely with <Line> elements previously returned no routing at all.
       // Only conductor layers reach here (skipLayers excludes REF-route/REF-both),
-      // and a Line is only counted when it carries start/end coordinates.
-      if (line.includes("<Line ")) {
+      // and a Line is only counted when it carries start/end coordinates. A
+      // <Line> inside a <Pad> is pad geometry, not routing, so it is inPad-guarded
+      // like <Polyline>/<Contour>.
+      if (!inPad && line.includes("<Line ")) {
         const sx = numAttr(line, "startX");
         const sy = numAttr(line, "startY");
         const ex = numAttr(line, "endX");
@@ -437,14 +442,18 @@ export const queryNet = async (
         // its OWN width when it carries one; only a trace with no descriptor of
         // its own falls back to a set/feature-level <LineDescRef>/inline width
         // (some tools attach one shared descriptor to a Set of bare features).
-        // 0 when nothing resolves.
-        if (wantSegments && setSegments.length > 0) {
+        // 0 when nothing resolves. Gated on currentLayerName for symmetry with
+        // the routeMap update above, so a layer-less <LayerFeature> never emits
+        // layer-"" segments.
+        if (wantSegments && currentLayerName && setSegments.length > 0) {
+          // Inline width wins over a reference, matching ownWidthRaw()'s
+          // primitive-level precedence so the tie-break is consistent.
           let setWidth = 0;
-          if (currentSetLineDescId) {
+          if (currentSetInlineWidth !== undefined) {
+            setWidth = Math.round(currentSetInlineWidth * factor);
+          } else if (currentSetLineDescId) {
             const w = lineDescDict.get(currentSetLineDescId);
             if (w !== undefined) setWidth = Math.round(w * factor);
-          } else if (currentSetInlineWidth !== undefined) {
-            setWidth = Math.round(currentSetInlineWidth * factor);
           }
           for (const s of setSegments) {
             const width =

--- a/src/tools/get-pcb-net.ts
+++ b/src/tools/get-pcb-net.ts
@@ -4,6 +4,8 @@ import type {
   ErrorResult,
   QueryNetResult,
   NetRouteInfo,
+  RoutingArc,
+  RoutingSegment,
   ViaCount,
   ViaDrill,
   ViaRow,
@@ -128,6 +130,10 @@ export const queryNet = async (
   const matchedNames = new Set(accumulators.keys());
   const skipLayers = new Set(["REF-route", "REF-both"]);
 
+  // Per-trace centerline geometry is only collected when the caller opts into
+  // detail="full"; in summary mode this stays false so Pass 3 does no extra work.
+  const wantSegments = detail === "full";
+
   let currentLayerName = "";
   let insideMatchedSet = false;
   let currentSetNetName = "";
@@ -138,6 +144,60 @@ export const queryNet = async (
   let inPolyline = false;
   let polyPoints: { x: number; y: number }[] = [];
   let polyLength = 0;
+
+  // Per-trace geometry collected for detail="full". `setSegments` holds the
+  // current <Set>'s traces; `ownWidthRaw` is the trace's OWN width descriptor
+  // (raw, pre-factor) captured from a <LineDescRef>/<LineDesc> child of that
+  // primitive. Traces without one fall back to the set/feature-level width at
+  // </Set>. `primRefId`/`primInlineWidth` accumulate the current primitive's own
+  // descriptor; `pendingLine`/`inLine` carry a <Line> across physical lines.
+  let segPoints: [number, number][] = [];
+  let segArcs: RoutingArc[] = [];
+  let primRefId: string | undefined;
+  let primInlineWidth: number | undefined;
+  let inLine = false;
+  let pendingLine: { layer: string; pts: [number, number][] } | null = null;
+  // Every conductor width (microns) seen in the current <Set>, so the per-layer
+  // rollup reports ALL distinct widths a Set uses (e.g. two <Line>s of different
+  // width), not just the last descriptor. Collected in summary mode too.
+  let setConductorWidths: number[] = [];
+  let setSegments: {
+    layer: string;
+    points: [number, number][];
+    arcs: RoutingArc[];
+    ownWidthRaw?: number;
+  }[] = [];
+
+  // Capture the current primitive's OWN width descriptor. A child <LineDesc
+  // lineWidth> is the most specific; otherwise a child <LineDescRef> id is
+  // resolved against the LineDesc dictionary at finalize time.
+  const captureOwnDesc = (l: string): void => {
+    if (l.includes("<LineDescRef ")) {
+      const id = attr(l, "id");
+      if (id) primRefId = id;
+    }
+    if (l.includes("<LineDesc ") && !l.includes("<EntryLineDesc ")) {
+      const w = numAttr(l, "lineWidth");
+      if (w !== undefined) primInlineWidth = w;
+    }
+  };
+  const ownWidthRaw = (): number | undefined => {
+    if (primInlineWidth !== undefined) return primInlineWidth;
+    if (primRefId !== undefined) return lineDescDict.get(primRefId);
+    return undefined;
+  };
+  const flushPendingLine = (): void => {
+    if (pendingLine) {
+      setSegments.push({
+        layer: pendingLine.layer,
+        points: pendingLine.pts,
+        arcs: [],
+        ownWidthRaw: ownWidthRaw(),
+      });
+      pendingLine = null;
+    }
+    inLine = false;
+  };
 
   await streamAllLines(filePath, (line) => {
     if (line.includes("<LayerFeature ")) {
@@ -154,7 +214,14 @@ export const queryNet = async (
       currentSetLineDescId = undefined;
       currentSetInlineWidth = undefined;
       inPad = false;
+      inPolyline = false;
       polyLength = 0;
+      setSegments = [];
+      setConductorWidths = [];
+      pendingLine = null;
+      inLine = false;
+      primRefId = undefined;
+      primInlineWidth = undefined;
     }
 
     if (insideMatchedSet) {
@@ -178,6 +245,13 @@ export const queryNet = async (
         currentSetHasConductor = true;
         inPolyline = true;
         polyPoints = [];
+        segPoints = [];
+        segArcs = [];
+        if (wantSegments) {
+          flushPendingLine(); // finalize a preceding self-closing <Line/>
+          primRefId = undefined;
+          primInlineWidth = undefined;
+        }
       }
 
       if (inPolyline) {
@@ -193,9 +267,41 @@ export const queryNet = async (
               polyLength += Math.sqrt(dx * dx + dy * dy);
             }
             polyPoints.push(pt);
+            if (wantSegments) segPoints.push([Math.round(pt.x), Math.round(pt.y)]);
           }
         }
+
+        // Curved vertices (<PolyStepCurve>) are only captured for the detail=
+        // "full" geometry export; summary length math (polyLength) deliberately
+        // ignores them, preserving the existing summary output unchanged.
+        if (wantSegments && line.includes("<PolyStepCurve ")) {
+          const x = numAttr(line, "x");
+          const y = numAttr(line, "y");
+          const cx = numAttr(line, "centerX");
+          const cy = numAttr(line, "centerY");
+          if (x !== undefined && y !== undefined && cx !== undefined && cy !== undefined) {
+            segPoints.push([Math.round(x * factor), Math.round(y * factor)]);
+            segArcs.push({
+              index: segPoints.length - 1,
+              centerX: Math.round(cx * factor),
+              centerY: Math.round(cy * factor),
+              clockwise: attr(line, "clockwise") === "true",
+            });
+          }
+        }
+
+        // The polyline's own width descriptor (child <LineDescRef>/<LineDesc>).
+        if (wantSegments) captureOwnDesc(line);
+
         if (line.includes("</Polyline>")) {
+          if (wantSegments && segPoints.length >= 2) {
+            setSegments.push({
+              layer: currentLayerName,
+              points: segPoints,
+              arcs: segArcs,
+              ownWidthRaw: ownWidthRaw(),
+            });
+          }
           inPolyline = false;
         }
       }
@@ -215,7 +321,34 @@ export const queryNet = async (
           const dx = (ex - sx) * factor;
           const dy = (ey - sy) * factor;
           polyLength += Math.sqrt(dx * dx + dy * dy);
+          if (wantSegments) {
+            // Begin a pending <Line> trace; its OWN width comes from a child
+            // <LineDescRef>/<LineDesc> (so two <Line>s in one <Set> keep their
+            // distinct widths). flush any prior unfinished line first.
+            flushPendingLine();
+            primRefId = undefined;
+            primInlineWidth = undefined;
+            pendingLine = {
+              layer: currentLayerName,
+              pts: [
+                [Math.round(sx * factor), Math.round(sy * factor)],
+                [Math.round(ex * factor), Math.round(ey * factor)],
+              ],
+            };
+            // Capture a same-line child descriptor, then finalize if the <Line>
+            // is closed (</Line>) or self-closed (/>) on this physical line.
+            captureOwnDesc(line);
+            if (line.includes("</Line>") || line.includes("/>")) flushPendingLine();
+            else inLine = true;
+          }
         }
+      }
+
+      // Continuation for a <Line> whose descriptor / close span multiple physical
+      // lines (the opening <Line ...> line is handled above).
+      if (wantSegments && inLine && !line.includes("<Line ")) {
+        captureOwnDesc(line);
+        if (line.includes("</Line>")) flushPendingLine();
       }
 
       // Poured copper: nets are frequently filled as <Contour> shapes (a polygon
@@ -237,13 +370,22 @@ export const queryNet = async (
       }
 
       if (line.includes("<LineDescRef ")) {
-        currentSetLineDescId = attr(line, "id");
+        const id = attr(line, "id");
+        currentSetLineDescId = id;
+        // Record this conductor's width for the rollup. inPad guards against a
+        // (rare) pad-level reference; the </Set> guard discards widths from any
+        // Set that turns out to carry no conductor geometry.
+        if (!inPad && id !== undefined) {
+          const w = lineDescDict.get(id);
+          if (w !== undefined) setConductorWidths.push(Math.round(w * factor));
+        }
       }
 
       if (line.includes("<LineDesc ") && !line.includes("<EntryLineDesc ")) {
         const inlineWidth = numAttr(line, "lineWidth");
         if (inlineWidth !== undefined) {
           currentSetInlineWidth = inlineWidth;
+          if (!inPad) setConductorWidths.push(Math.round(inlineWidth * factor));
         }
       }
 
@@ -265,6 +407,8 @@ export const queryNet = async (
       }
 
       if (line.includes("</Set>")) {
+        if (wantSegments) flushPendingLine(); // finalize a trailing self-closing <Line/>
+
         if (currentSetHasConductor && currentLayerName) {
           if (!acc.routeMap.has(currentLayerName)) {
             acc.routeMap.set(currentLayerName, { widths: new Set(), segments: 0, traceLength: 0 });
@@ -273,13 +417,30 @@ export const queryNet = async (
           layerRoute.segments++;
           layerRoute.traceLength += polyLength;
 
+          // Add every distinct conductor width the Set used (a Set may carry
+          // several primitives of differing width); the widths Set dedupes.
+          for (const w of setConductorWidths) layerRoute.widths.add(w);
+        }
+
+        // Flush this Set's per-trace geometry (detail="full"). Each trace reports
+        // its OWN width when it carries one; only a trace with no descriptor of
+        // its own falls back to a set/feature-level <LineDescRef>/inline width
+        // (some tools attach one shared descriptor to a Set of bare features).
+        // 0 when nothing resolves.
+        if (wantSegments && setSegments.length > 0) {
+          let setWidth = 0;
           if (currentSetLineDescId) {
-            const width = lineDescDict.get(currentSetLineDescId);
-            if (width !== undefined) {
-              layerRoute.widths.add(Math.round(width * factor));
-            }
+            const w = lineDescDict.get(currentSetLineDescId);
+            if (w !== undefined) setWidth = Math.round(w * factor);
           } else if (currentSetInlineWidth !== undefined) {
-            layerRoute.widths.add(Math.round(currentSetInlineWidth * factor));
+            setWidth = Math.round(currentSetInlineWidth * factor);
+          }
+          for (const s of setSegments) {
+            const width =
+              s.ownWidthRaw !== undefined ? Math.round(s.ownWidthRaw * factor) : setWidth;
+            const seg: RoutingSegment = { layer: s.layer, width, points: s.points };
+            if (s.arcs.length > 0) seg.arcs = s.arcs;
+            acc.segments.push(seg);
           }
         }
 
@@ -368,6 +529,14 @@ export const queryNet = async (
           if (capped.truncated) result.truncated = true;
         }
       }
+      if (detail === "full" && acc.segments.length > 0) {
+        // Per-trace centerline geometry, stratified by layer so a truncated
+        // sample still represents every routed layer. The per-layer rollup
+        // (routing[].segmentCount) carries the true Set-level totals.
+        const cappedSegs = capRowsStratified(acc.segments, MAX_COORD_ROWS, (s) => s.layer);
+        result.segments = cappedSegs.rows;
+        if (cappedSegs.truncated) result.truncated = true;
+      }
       if (totalSegments > 0) {
         result.totalSegments = totalSegments;
       }
@@ -389,7 +558,7 @@ export const register = (server: McpServer): void => {
     "get_pcb_net",
     {
       description:
-        "Query nets by name pattern in an IPC-2581 file. Returns grouped connected pins, per-layer routing, and a compact via rollup (count per drill type). Routing is read from conductor-layer copper geometry in the export (Polyline/Line centerline traces and poured Contour shapes); trace widths and lengths are reported for centerline-routed copper and are absent for shape/plane-routed (poured) copper, which has no centerline. If the IPC-2581 export was generated without conductor/etch (cline) feature output, the file carries no conductor geometry and routing is empty even though pins, vias, and layersUsed still populate. Pass detail='full' for raw per-via coordinates (capped). Rejects patterns that match all nets.",
+        "Query nets by name pattern in an IPC-2581 file. Returns grouped connected pins, per-layer routing, and a compact via rollup (count per drill type). Routing is read from conductor-layer copper geometry in the export (Polyline/Line centerline traces and poured Contour shapes); trace widths and lengths are reported for centerline-routed copper and are absent for shape/plane-routed (poured) copper, which has no centerline. If the IPC-2581 export was generated without conductor/etch (cline) feature output, the file carries no conductor geometry and routing is empty even though pins, vias, and layersUsed still populate. Pass detail='full' for raw per-via coordinates and per-trace centerline geometry (each Polyline/Line as vertices + width + arcs), both capped. Poured shapes have no centerline and are absent from the per-trace geometry; segments[].length is per-primitive and does not equal totalSegments (Set-level). Rejects patterns that match all nets.",
       inputSchema: {
         file: z.string().describe("Path to IPC-2581 XML file"),
         pattern: z
@@ -399,7 +568,7 @@ export const register = (server: McpServer): void => {
           .enum(["summary", "full"])
           .default("summary")
           .describe(
-            "Response detail. 'summary' (default) returns via counts only; 'full' adds raw per-via x/y coordinates (capped to stay within the response budget)."
+            "Response detail. 'summary' (default) returns via counts and the per-layer routing rollup only. 'full' (must be set explicitly) additionally returns raw per-via x/y coordinates and per-trace centerline geometry (segments[]: vertices, width, arcs), both capped to stay within the response budget."
           ),
       },
     },

--- a/src/tools/lib/types.ts
+++ b/src/tools/lib/types.ts
@@ -157,6 +157,33 @@ export interface NetRouteInfo {
 }
 
 /**
+ * A curved vertex within a routing trace (IPC-2581 <PolyStepCurve>). `index` is
+ * the position in the trace's `points` array that this arc terminates at; the
+ * arc sweeps from the previous vertex to `points[index]` around (centerX,
+ * centerY). All coordinates are microns.
+ */
+export interface RoutingArc {
+  index: number;
+  centerX: number;
+  centerY: number;
+  clockwise: boolean;
+}
+
+/**
+ * A single centerline routing trace: one <Polyline> or <Line> conductor
+ * primitive. `width` is in microns (0 when no LineDesc resolved); `points` are
+ * the trace vertices in microns (>=2). `arcs` is present only when the trace
+ * contains curved (<PolyStepCurve>) vertices. Poured copper (<Contour>) has no
+ * centerline and is NOT represented here.
+ */
+export interface RoutingSegment {
+  layer: string;
+  width: number;
+  points: [number, number][];
+  arcs?: RoutingArc[];
+}
+
+/**
  * Unique via drill type. Internal only: used while deduplicating drill types to
  * build `viaCounts` and the `viaRows` drillIndex; it is not part of any response.
  */
@@ -213,6 +240,18 @@ export interface QueryNetResult {
   /** Per-via coordinates. Only included when detail="full" is requested. */
   viaColumns?: ["x", "y", "drillIndex"];
   viaRows?: ViaRow[];
+  /**
+   * Per-trace centerline routing geometry, one entry per <Polyline>/<Line>
+   * conductor primitive. Only included when detail="full"; capped (and the
+   * result flagged `truncated`) to stay within the response budget.
+   *
+   * NOTE: `segments.length` is per-primitive and intentionally does NOT equal
+   * `totalSegments` / `routing[].segmentCount`, which are Set-level (a <Set>
+   * with multiple shapes counts once, and poured shapes count too). Poured
+   * copper has no centerline and is absent from `segments` entirely; rely on
+   * the `routing[]` rollup for poured-net presence.
+   */
+  segments?: RoutingSegment[];
   totalSegments?: number;
   totalVias?: number;
   totalTraceLength?: number;

--- a/src/tools/lib/types.ts
+++ b/src/tools/lib/types.ts
@@ -149,10 +149,18 @@ export interface NetPin {
  */
 export interface NetRouteInfo {
   layerName: string;
+  // Distinct conductor widths (microns) referenced by the traces on this layer.
+  // It reflects every width descriptor the layer's conductors carry; in the rare
+  // case a single trace carries both an inline width and a width reference, both
+  // appear here even though only one is the trace's effective width (see each
+  // trace's exact width in `segments[].width` with detail="full").
   traceWidths: number[];
   // Number of conductor-bearing <Set> elements on the layer (centerline traces
   // and/or poured shapes); a Set with multiple shapes counts once.
   segmentCount: number;
+  // Sum of straight-span lengths in microns. Curved (arc) spans are not added,
+  // so this undercounts traces that contain arcs; treat it as a lower bound on
+  // such nets.
   traceLength: number;
 }
 
@@ -160,7 +168,9 @@ export interface NetRouteInfo {
  * A curved vertex within a routing trace (IPC-2581 <PolyStepCurve>). `index` is
  * the position in the trace's `points` array that this arc terminates at; the
  * arc sweeps from the previous vertex to `points[index]` around (centerX,
- * centerY). All coordinates are microns.
+ * centerY). `index` is always >= 1: a trace always opens with a straight
+ * starting vertex, so a curve can never be the first point. All coordinates are
+ * microns.
  */
 export interface RoutingArc {
   index: number;

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -219,7 +219,7 @@ export const validatePattern = (pattern: string): { error: string } | { regex: R
 // Net Accumulator (used by get-pcb-net)
 // =============================================================================
 
-import type { NetPin } from "./lib/types.js";
+import type { NetPin, RoutingSegment } from "./lib/types.js";
 
 export interface RawVia {
   x: number;
@@ -228,12 +228,19 @@ export interface RawVia {
   layer: string;
 }
 
+/**
+ * Raw per-trace routing geometry collected during scanning. Same shape as the
+ * response `RoutingSegment`; only populated when detail="full" is requested.
+ */
+export type RawSegment = RoutingSegment;
+
 export interface NetAccumulator {
   pins: NetPin[];
   pinsSeen: Set<string>;
   phyNetLayers: Set<string>;
   routeMap: Map<string, { widths: Set<number>; segments: number; traceLength: number }>;
   vias: RawVia[];
+  segments: RawSegment[];
 }
 
 export const makeAccumulator = (): NetAccumulator => ({
@@ -242,6 +249,7 @@ export const makeAccumulator = (): NetAccumulator => ({
   phyNetLayers: new Set(),
   routeMap: new Map(),
   vias: [],
+  segments: [],
 });
 
 export const addPin = (acc: NetAccumulator, refdes: string, pin: string): void => {


### PR DESCRIPTION
## Summary

Minor release (`1.0.4` → `1.1.0`). Adds a detailed per-trace routing export to `get_pcb_net` and tightens conductor-width reporting to reflect exactly what's in the layout.

### Added — `segments` (opt-in, `detail="full"`)
`get_pcb_net` with `detail="full"` now returns a `segments` array of per-trace centerline geometry alongside the existing per-via coordinates. Each entry is one `<Polyline>`/`<Line>` conductor:

```jsonc
{ "layer": "TOP", "width": 150, "points": [[0,0],[1000,0],[1000,2000]],
  "arcs": [{ "index": 2, "centerX": 41910, "centerY": 55880, "clockwise": false }] }
```

- `arcs` carries full `<PolyStepCurve>` curvature (`index`, `centerX`, `centerY`, `clockwise`); `<PolyStepCurve>` was previously dropped entirely.
- Stratified by layer, capped at `MAX_COORD_ROWS = 300`, flags `truncated`. The per-layer `routing` rollup keeps the true Set-level totals.
- **Opt-in only**: `summary` (default) is byte-for-byte unchanged and emits no `segments`.
- Poured `<Contour>` copper has no centerline and is excluded; the rollup still reports it routed.
- `segments.length` is per-primitive and intentionally differs from `totalSegments` / `routing[].segmentCount` (Set-level).

### Changed — exact per-conductor widths
- Each trace reports its **own** width from its `<LineDescRef>`/`<LineDesc>`, falling back to a set/feature-level descriptor only when it carries none of its own. Two `<Line>`s of differing width in one `<Set>` now keep their distinct widths instead of collapsing to the last descriptor seen.
- The summary `routing[].traceWidths` rollup is tightened the same way: it now lists **every** distinct conductor width a `<Set>` uses.

This is backward-compatible in shape (`traceWidths` is still `number[]`); for a multi-primitive `<Set>` it may now report **more** widths (an accuracy fix, strict superset).

## Tests
- 184/184 pass (57 in `get-pcb-net.test.ts`); `type-check` + `lint` clean.
- New unit coverage: per-trace polyline/line/arc geometry, per-`<Line>` width in a shared `<Set>`, polyline-local width override, pour exclusion, multi-net independence, stratified cap + truncation, tightened rollup widths.
- New **real-fixture** regressions (skipped if fixtures absent; CI downloads them): `testcase1-RevC` per-trace segments consistency, `testcase3-RevC` real `<PolyStepCurve>` arc capture.

## Notes for reviewers
- The OpenTelemetry e2e suite was not run locally (it binds a TCP port; sandboxed env blocks `listen`) — CI covers it. All other suites pass.
- Per-trace width *fallback* still uses the set/feature-level descriptor only when a primitive has none of its own — the legitimate IPC case of one shared descriptor over a `<Set>` of bare features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)